### PR TITLE
Async tiles and redis destination

### DIFF
--- a/lib/cubits/all.dart
+++ b/lib/cubits/all.dart
@@ -19,6 +19,7 @@ final List<SingleChildWidget> allCubits = [
   BlocProvider(create: BluetoothSync.create),
   BlocProvider(create: GpsSync.create),
   BlocProvider(create: InternetSync.create),
+  BlocProvider(create: NavigationSync.create),
   BlocProvider(create: SystemCubit.create),
   BlocProvider(create: TripCubit.create),
   BlocProvider(create: MapCubit.create),

--- a/lib/cubits/map_cubit.freezed.dart
+++ b/lib/cubits/map_cubit.freezed.dart
@@ -501,7 +501,7 @@ class MapOffline implements MapState {
       {required this.controller,
       required this.position,
       required this.orientation,
-      required this.mbTiles,
+      required this.tiles,
       required this.theme,
       this.onReady,
       this.isReady = false,
@@ -515,7 +515,7 @@ class MapOffline implements MapState {
   final LatLng position;
   @override
   final double orientation;
-  final MbTiles mbTiles;
+  final VectorTileProvider tiles;
   final Theme theme;
   final void Function(TickerProvider)? onReady;
   @JsonKey()
@@ -549,7 +549,7 @@ class MapOffline implements MapState {
                 other.position == position) &&
             (identical(other.orientation, orientation) ||
                 other.orientation == orientation) &&
-            (identical(other.mbTiles, mbTiles) || other.mbTiles == mbTiles) &&
+            (identical(other.tiles, tiles) || other.tiles == tiles) &&
             (identical(other.theme, theme) || other.theme == theme) &&
             (identical(other.onReady, onReady) || other.onReady == onReady) &&
             (identical(other.isReady, isReady) || other.isReady == isReady) &&
@@ -566,7 +566,7 @@ class MapOffline implements MapState {
       controller,
       position,
       orientation,
-      mbTiles,
+      tiles,
       theme,
       onReady,
       isReady,
@@ -576,7 +576,7 @@ class MapOffline implements MapState {
 
   @override
   String toString() {
-    return 'MapState.offline(controller: $controller, position: $position, orientation: $orientation, mbTiles: $mbTiles, theme: $theme, onReady: $onReady, isReady: $isReady, route: $route, nextInstruction: $nextInstruction, destination: $destination)';
+    return 'MapState.offline(controller: $controller, position: $position, orientation: $orientation, tiles: $tiles, theme: $theme, onReady: $onReady, isReady: $isReady, route: $route, nextInstruction: $nextInstruction, destination: $destination)';
   }
 }
 
@@ -592,7 +592,7 @@ abstract mixin class $MapOfflineCopyWith<$Res>
       {MapController controller,
       LatLng position,
       double orientation,
-      MbTiles mbTiles,
+      VectorTileProvider tiles,
       Theme theme,
       void Function(TickerProvider)? onReady,
       bool isReady,
@@ -621,7 +621,7 @@ class _$MapOfflineCopyWithImpl<$Res> implements $MapOfflineCopyWith<$Res> {
     Object? controller = null,
     Object? position = null,
     Object? orientation = null,
-    Object? mbTiles = null,
+    Object? tiles = null,
     Object? theme = null,
     Object? onReady = freezed,
     Object? isReady = null,
@@ -642,10 +642,10 @@ class _$MapOfflineCopyWithImpl<$Res> implements $MapOfflineCopyWith<$Res> {
           ? _self.orientation
           : orientation // ignore: cast_nullable_to_non_nullable
               as double,
-      mbTiles: null == mbTiles
-          ? _self.mbTiles
-          : mbTiles // ignore: cast_nullable_to_non_nullable
-              as MbTiles,
+      tiles: null == tiles
+          ? _self.tiles
+          : tiles // ignore: cast_nullable_to_non_nullable
+              as VectorTileProvider,
       theme: null == theme
           ? _self.theme
           : theme // ignore: cast_nullable_to_non_nullable

--- a/lib/cubits/map_state.dart
+++ b/lib/cubits/map_state.dart
@@ -26,7 +26,7 @@ sealed class MapState with _$MapState {
     required MapController controller,
     required LatLng position,
     required double orientation,
-    required MbTiles mbTiles,
+    required VectorTileProvider tiles,
     required Theme theme,
     void Function(TickerProvider)? onReady,
     @Default(false) bool isReady,

--- a/lib/cubits/mdb_cubits.dart
+++ b/lib/cubits/mdb_cubits.dart
@@ -7,6 +7,7 @@ import '../state/bluetooth.dart';
 import '../state/engine.dart';
 import '../state/gps.dart';
 import '../state/internet.dart';
+import '../state/navigation.dart';
 import '../state/vehicle.dart';
 import 'syncable_cubit.dart';
 
@@ -98,4 +99,15 @@ class InternetSync extends SyncableCubit<InternetData> {
 
   InternetSync(MDBRepository repo)
       : super(redisRepository: repo, initialState: InternetData());
+}
+
+class NavigationSync extends SyncableCubit<NavigationData> {
+  static NavigationData watch(BuildContext context) =>
+      context.watch<NavigationSync>().state;
+
+  static NavigationSync create(BuildContext context) =>
+      NavigationSync(RepositoryProvider.of<MDBRepository>(context))..start();
+
+  NavigationSync(MDBRepository repo)
+      : super(redisRepository: repo, initialState: NavigationData());
 }

--- a/lib/map/mbtiles_provider.dart
+++ b/lib/map/mbtiles_provider.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:flutter/services.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mbtiles/mbtiles.dart';
+import 'package:vector_map_tiles/vector_map_tiles.dart';
+
+import '../repositories/tiles_repository.dart';
+
+part 'mbtiles_provider.freezed.dart';
+
+@freezed
+sealed class _Request with _$Request {
+  const factory _Request.getTile(String requestId, TileIdentity tile) =
+      _GetTileRequest;
+  const factory _Request.dispose() = _DisposeRequest;
+  const factory _Request.init(TilesRepository tilesRepository) = _InitRequest;
+}
+
+@freezed
+sealed class _Response with _$Response {
+  const factory _Response.tile(String requestId, Uint8List tile) =
+      _TileResponse;
+  const factory _Response.error(String requestId, String message) =
+      _ErrorResponse;
+  const factory _Response.init(InitResult result) = _InitResponse;
+}
+
+@freezed
+sealed class InitResult with _$InitResult {
+  const factory InitResult.success(MbTilesMetadata metadata) = InitSuccess;
+  const factory InitResult.error(String message) = InitError;
+}
+
+class AsyncMbTilesProvider implements VectorTileProvider {
+  late final ReceivePort _receivePort;
+  late final SendPort _sendPort;
+  final Map<String, Completer<Uint8List>> _pendingRequests = {};
+  final TilesRepository tilesRepository;
+
+  Completer<InitResult>? _initCompleter;
+  MbTilesMetadata? _metadata;
+
+  AsyncMbTilesProvider(this.tilesRepository) {
+    _receivePort = ReceivePort();
+  }
+
+  Future<InitResult> init() async {
+    _receivePort.listen(_handleResponse);
+
+    final token = RootIsolateToken.instance;
+    if (token == null) {
+      throw Exception('RootIsolateToken is not available');
+    }
+    await Isolate.spawn(_startRemoteIsolate, (_receivePort.sendPort, token));
+
+    final completer = Completer<InitResult>();
+    _initCompleter = completer;
+
+    return completer.future;
+  }
+
+  void _handleResponse(dynamic message) {
+    if (message is _Response) {
+      switch (message) {
+        case _InitResponse(:final result):
+          _initCompleter?.complete(result);
+          _initCompleter = null;
+          if (result is InitSuccess) {
+            _metadata = result.metadata;
+          }
+        case _TileResponse(:final requestId, :final tile):
+          _pendingRequests[requestId]?.complete(tile);
+          _pendingRequests.remove(requestId);
+        case _ErrorResponse(:final requestId, :final message):
+          _pendingRequests[requestId]?.completeError(message);
+          _pendingRequests.remove(requestId);
+      }
+    } else if (message is SendPort) {
+      _sendPort = message;
+      _sendPort.send(_Request.init(tilesRepository));
+    }
+  }
+
+  @override
+  int get maximumZoom => _metadata?.maxZoom?.toInt() ?? 20;
+
+  @override
+  int get minimumZoom => _metadata?.minZoom?.toInt() ?? 0;
+
+  @override
+  Future<Uint8List> provide(TileIdentity tile) {
+    final requestId = '${tile.z}/${tile.x}/${tile.y}';
+    final completer = Completer<Uint8List>();
+    _pendingRequests[requestId] = completer;
+
+    _sendPort.send(_Request.getTile(requestId, tile));
+    return completer.future;
+  }
+
+  @override
+  TileProviderType get type => TileProviderType.vector;
+
+  void dispose() {
+    _sendPort.send(const _Request.dispose());
+    _receivePort.close();
+  }
+}
+
+void _startRemoteIsolate((SendPort, RootIsolateToken) init) {
+  final receivePort = ReceivePort();
+  final (initPort, token) = init;
+  BackgroundIsolateBinaryMessenger.ensureInitialized(token);
+  initPort.send(receivePort.sendPort);
+
+  MbTiles? _mbTiles;
+
+  receivePort.listen((message) async {
+    if (message is _Request) {
+      switch (message) {
+        case _InitRequest(:final tilesRepository):
+          final tiles = await tilesRepository.getMbTiles();
+          switch (tiles) {
+            case Success(:final mbTiles):
+              _mbTiles = mbTiles;
+
+              final meta = mbTiles.getMetadata();
+              initPort.send(_Response.init(InitResult.success(meta)));
+            case NotFound():
+              initPort
+                  .send(_Response.init(InitResult.error('Map file not found')));
+            case Error(:final message):
+              initPort.send(_Response.init(InitResult.error(message)));
+          }
+        case _GetTileRequest(:final requestId, :final tile):
+          if (_mbTiles == null) {
+            initPort
+                .send(_Response.error(requestId, 'MBTiles not initialized'));
+            return;
+          }
+          final tmsY = ((1 << tile.z) - 1) - tile.y;
+          final tileData = _mbTiles!.getTile(x: tile.x, y: tmsY, z: tile.z);
+          if (tileData == null) {
+            initPort.send(_Response.error(requestId, 'Tile not found'));
+            return;
+          }
+          initPort.send(_Response.tile(requestId, tileData));
+        case _DisposeRequest():
+          _mbTiles?.dispose();
+          receivePort.close();
+          Isolate.exit();
+      }
+    }
+  });
+}

--- a/lib/map/mbtiles_provider.freezed.dart
+++ b/lib/map/mbtiles_provider.freezed.dart
@@ -1,0 +1,585 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'mbtiles_provider.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Request {
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _Request);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() {
+    return '_Request()';
+  }
+}
+
+/// @nodoc
+class _$RequestCopyWith<$Res> {
+  _$RequestCopyWith(_Request _, $Res Function(_Request) __);
+}
+
+/// @nodoc
+
+class _GetTileRequest implements _Request {
+  const _GetTileRequest(this.requestId, this.tile);
+
+  final String requestId;
+  final TileIdentity tile;
+
+  /// Create a copy of _Request
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$GetTileRequestCopyWith<_GetTileRequest> get copyWith =>
+      __$GetTileRequestCopyWithImpl<_GetTileRequest>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _GetTileRequest &&
+            (identical(other.requestId, requestId) ||
+                other.requestId == requestId) &&
+            (identical(other.tile, tile) || other.tile == tile));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, requestId, tile);
+
+  @override
+  String toString() {
+    return '_Request.getTile(requestId: $requestId, tile: $tile)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$GetTileRequestCopyWith<$Res>
+    implements _$RequestCopyWith<$Res> {
+  factory _$GetTileRequestCopyWith(
+          _GetTileRequest value, $Res Function(_GetTileRequest) _then) =
+      __$GetTileRequestCopyWithImpl;
+  @useResult
+  $Res call({String requestId, TileIdentity tile});
+}
+
+/// @nodoc
+class __$GetTileRequestCopyWithImpl<$Res>
+    implements _$GetTileRequestCopyWith<$Res> {
+  __$GetTileRequestCopyWithImpl(this._self, this._then);
+
+  final _GetTileRequest _self;
+  final $Res Function(_GetTileRequest) _then;
+
+  /// Create a copy of _Request
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? requestId = null,
+    Object? tile = null,
+  }) {
+    return _then(_GetTileRequest(
+      null == requestId
+          ? _self.requestId
+          : requestId // ignore: cast_nullable_to_non_nullable
+              as String,
+      null == tile
+          ? _self.tile
+          : tile // ignore: cast_nullable_to_non_nullable
+              as TileIdentity,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _DisposeRequest implements _Request {
+  const _DisposeRequest();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _DisposeRequest);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() {
+    return '_Request.dispose()';
+  }
+}
+
+/// @nodoc
+
+class _InitRequest implements _Request {
+  const _InitRequest(this.tilesRepository);
+
+  final TilesRepository tilesRepository;
+
+  /// Create a copy of _Request
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$InitRequestCopyWith<_InitRequest> get copyWith =>
+      __$InitRequestCopyWithImpl<_InitRequest>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _InitRequest &&
+            (identical(other.tilesRepository, tilesRepository) ||
+                other.tilesRepository == tilesRepository));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, tilesRepository);
+
+  @override
+  String toString() {
+    return '_Request.init(tilesRepository: $tilesRepository)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$InitRequestCopyWith<$Res>
+    implements _$RequestCopyWith<$Res> {
+  factory _$InitRequestCopyWith(
+          _InitRequest value, $Res Function(_InitRequest) _then) =
+      __$InitRequestCopyWithImpl;
+  @useResult
+  $Res call({TilesRepository tilesRepository});
+}
+
+/// @nodoc
+class __$InitRequestCopyWithImpl<$Res> implements _$InitRequestCopyWith<$Res> {
+  __$InitRequestCopyWithImpl(this._self, this._then);
+
+  final _InitRequest _self;
+  final $Res Function(_InitRequest) _then;
+
+  /// Create a copy of _Request
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? tilesRepository = null,
+  }) {
+    return _then(_InitRequest(
+      null == tilesRepository
+          ? _self.tilesRepository
+          : tilesRepository // ignore: cast_nullable_to_non_nullable
+              as TilesRepository,
+    ));
+  }
+}
+
+/// @nodoc
+mixin _$Response {
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _Response);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() {
+    return '_Response()';
+  }
+}
+
+/// @nodoc
+class _$ResponseCopyWith<$Res> {
+  _$ResponseCopyWith(_Response _, $Res Function(_Response) __);
+}
+
+/// @nodoc
+
+class _TileResponse implements _Response {
+  const _TileResponse(this.requestId, this.tile);
+
+  final String requestId;
+  final Uint8List tile;
+
+  /// Create a copy of _Response
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$TileResponseCopyWith<_TileResponse> get copyWith =>
+      __$TileResponseCopyWithImpl<_TileResponse>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _TileResponse &&
+            (identical(other.requestId, requestId) ||
+                other.requestId == requestId) &&
+            const DeepCollectionEquality().equals(other.tile, tile));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, requestId, const DeepCollectionEquality().hash(tile));
+
+  @override
+  String toString() {
+    return '_Response.tile(requestId: $requestId, tile: $tile)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$TileResponseCopyWith<$Res>
+    implements _$ResponseCopyWith<$Res> {
+  factory _$TileResponseCopyWith(
+          _TileResponse value, $Res Function(_TileResponse) _then) =
+      __$TileResponseCopyWithImpl;
+  @useResult
+  $Res call({String requestId, Uint8List tile});
+}
+
+/// @nodoc
+class __$TileResponseCopyWithImpl<$Res>
+    implements _$TileResponseCopyWith<$Res> {
+  __$TileResponseCopyWithImpl(this._self, this._then);
+
+  final _TileResponse _self;
+  final $Res Function(_TileResponse) _then;
+
+  /// Create a copy of _Response
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? requestId = null,
+    Object? tile = null,
+  }) {
+    return _then(_TileResponse(
+      null == requestId
+          ? _self.requestId
+          : requestId // ignore: cast_nullable_to_non_nullable
+              as String,
+      null == tile
+          ? _self.tile
+          : tile // ignore: cast_nullable_to_non_nullable
+              as Uint8List,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _ErrorResponse implements _Response {
+  const _ErrorResponse(this.requestId, this.message);
+
+  final String requestId;
+  final String message;
+
+  /// Create a copy of _Response
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ErrorResponseCopyWith<_ErrorResponse> get copyWith =>
+      __$ErrorResponseCopyWithImpl<_ErrorResponse>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ErrorResponse &&
+            (identical(other.requestId, requestId) ||
+                other.requestId == requestId) &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, requestId, message);
+
+  @override
+  String toString() {
+    return '_Response.error(requestId: $requestId, message: $message)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ErrorResponseCopyWith<$Res>
+    implements _$ResponseCopyWith<$Res> {
+  factory _$ErrorResponseCopyWith(
+          _ErrorResponse value, $Res Function(_ErrorResponse) _then) =
+      __$ErrorResponseCopyWithImpl;
+  @useResult
+  $Res call({String requestId, String message});
+}
+
+/// @nodoc
+class __$ErrorResponseCopyWithImpl<$Res>
+    implements _$ErrorResponseCopyWith<$Res> {
+  __$ErrorResponseCopyWithImpl(this._self, this._then);
+
+  final _ErrorResponse _self;
+  final $Res Function(_ErrorResponse) _then;
+
+  /// Create a copy of _Response
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? requestId = null,
+    Object? message = null,
+  }) {
+    return _then(_ErrorResponse(
+      null == requestId
+          ? _self.requestId
+          : requestId // ignore: cast_nullable_to_non_nullable
+              as String,
+      null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _InitResponse implements _Response {
+  const _InitResponse(this.result);
+
+  final InitResult result;
+
+  /// Create a copy of _Response
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$InitResponseCopyWith<_InitResponse> get copyWith =>
+      __$InitResponseCopyWithImpl<_InitResponse>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _InitResponse &&
+            (identical(other.result, result) || other.result == result));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, result);
+
+  @override
+  String toString() {
+    return '_Response.init(result: $result)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$InitResponseCopyWith<$Res>
+    implements _$ResponseCopyWith<$Res> {
+  factory _$InitResponseCopyWith(
+          _InitResponse value, $Res Function(_InitResponse) _then) =
+      __$InitResponseCopyWithImpl;
+  @useResult
+  $Res call({InitResult result});
+
+  $InitResultCopyWith<$Res> get result;
+}
+
+/// @nodoc
+class __$InitResponseCopyWithImpl<$Res>
+    implements _$InitResponseCopyWith<$Res> {
+  __$InitResponseCopyWithImpl(this._self, this._then);
+
+  final _InitResponse _self;
+  final $Res Function(_InitResponse) _then;
+
+  /// Create a copy of _Response
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? result = null,
+  }) {
+    return _then(_InitResponse(
+      null == result
+          ? _self.result
+          : result // ignore: cast_nullable_to_non_nullable
+              as InitResult,
+    ));
+  }
+
+  /// Create a copy of _Response
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $InitResultCopyWith<$Res> get result {
+    return $InitResultCopyWith<$Res>(_self.result, (value) {
+      return _then(_self.copyWith(result: value));
+    });
+  }
+}
+
+/// @nodoc
+mixin _$InitResult {
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is InitResult);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() {
+    return 'InitResult()';
+  }
+}
+
+/// @nodoc
+class $InitResultCopyWith<$Res> {
+  $InitResultCopyWith(InitResult _, $Res Function(InitResult) __);
+}
+
+/// @nodoc
+
+class InitSuccess implements InitResult {
+  const InitSuccess(this.metadata);
+
+  final MbTilesMetadata metadata;
+
+  /// Create a copy of InitResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $InitSuccessCopyWith<InitSuccess> get copyWith =>
+      _$InitSuccessCopyWithImpl<InitSuccess>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is InitSuccess &&
+            (identical(other.metadata, metadata) ||
+                other.metadata == metadata));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, metadata);
+
+  @override
+  String toString() {
+    return 'InitResult.success(metadata: $metadata)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $InitSuccessCopyWith<$Res>
+    implements $InitResultCopyWith<$Res> {
+  factory $InitSuccessCopyWith(
+          InitSuccess value, $Res Function(InitSuccess) _then) =
+      _$InitSuccessCopyWithImpl;
+  @useResult
+  $Res call({MbTilesMetadata metadata});
+}
+
+/// @nodoc
+class _$InitSuccessCopyWithImpl<$Res> implements $InitSuccessCopyWith<$Res> {
+  _$InitSuccessCopyWithImpl(this._self, this._then);
+
+  final InitSuccess _self;
+  final $Res Function(InitSuccess) _then;
+
+  /// Create a copy of InitResult
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? metadata = null,
+  }) {
+    return _then(InitSuccess(
+      null == metadata
+          ? _self.metadata
+          : metadata // ignore: cast_nullable_to_non_nullable
+              as MbTilesMetadata,
+    ));
+  }
+}
+
+/// @nodoc
+
+class InitError implements InitResult {
+  const InitError(this.message);
+
+  final String message;
+
+  /// Create a copy of InitResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $InitErrorCopyWith<InitError> get copyWith =>
+      _$InitErrorCopyWithImpl<InitError>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is InitError &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  @override
+  String toString() {
+    return 'InitResult.error(message: $message)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $InitErrorCopyWith<$Res>
+    implements $InitResultCopyWith<$Res> {
+  factory $InitErrorCopyWith(InitError value, $Res Function(InitError) _then) =
+      _$InitErrorCopyWithImpl;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class _$InitErrorCopyWithImpl<$Res> implements $InitErrorCopyWith<$Res> {
+  _$InitErrorCopyWithImpl(this._self, this._then);
+
+  final InitError _self;
+  final $Res Function(InitError) _then;
+
+  /// Create a copy of InitResult
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(InitError(
+      null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/screens/address_selection_screen.dart
+++ b/lib/screens/address_selection_screen.dart
@@ -8,6 +8,7 @@ import '../cubits/mdb_cubits.dart';
 import '../cubits/screen_cubit.dart';
 import '../cubits/theme_cubit.dart';
 import '../repositories/address_repository.dart';
+import '../repositories/mdb_repository.dart';
 import '../widgets/general/control_gestures_detector.dart';
 import '../widgets/general/control_hints.dart';
 import '../widgets/location_dial/location_dial.dart';
@@ -42,6 +43,10 @@ class _AddressSelectionScreenState extends State<AddressSelectionScreen> {
         onSubmit: (code) {
           final address = addresses[code];
           if (address != null) {
+            final mdbRepo = context.read<MDBRepository>();
+            final coordinates =
+                "${address.coordinates.latitude},${address.coordinates.longitude}";
+            mdbRepo.set("navigation", "destination", coordinates);
             mapCubit.startNavigation(address.coordinates);
           }
           screenCubit.showMap();
@@ -55,6 +60,7 @@ class _AddressSelectionScreenState extends State<AddressSelectionScreen> {
     final screenCubit = context.read<ScreenCubit>();
     final mapCubit = context.read<MapCubit>();
     final addressCubit = context.watch<AddressCubit>();
+
     final ThemeState(:theme, :isDark) = ThemeCubit.watch(context);
 
     final child = switch (addressCubit.state) {

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -83,7 +83,7 @@ class MapScreen extends StatelessWidget {
             orientation: orientation,
           ),
         MapOffline(
-          :final mbTiles,
+          :final tiles,
           :final position,
           :final controller,
           :final theme,
@@ -94,7 +94,7 @@ class MapScreen extends StatelessWidget {
           :final destination,
         ) =>
           OfflineMapView(
-            mbTiles: mbTiles,
+            tiles: tiles,
             mapController: controller,
             theme: theme,
             position: position,

--- a/lib/state/navigation.dart
+++ b/lib/state/navigation.dart
@@ -1,0 +1,16 @@
+import 'package:equatable/equatable.dart';
+
+import '../builders/sync/annotations.dart';
+import '../builders/sync/settings.dart';
+
+part 'navigation.g.dart';
+
+@StateClass("navigation", Duration(seconds: 5))
+class NavigationData extends Equatable with $NavigationData {
+  @StateField()
+  final String destination;
+
+  NavigationData({
+    this.destination = "",
+  });
+}

--- a/lib/state/navigation.g.dart
+++ b/lib/state/navigation.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'navigation.dart';
+
+// **************************************************************************
+// StateGenerator
+// **************************************************************************
+
+abstract mixin class $NavigationData implements Syncable<NavigationData> {
+  String get destination;
+  get syncSettings => SyncSettings(
+      "navigation",
+      Duration(microseconds: 5000000),
+      [
+        SyncFieldSettings(
+            name: "destination",
+            variable: "destination",
+            type: SyncFieldType.string,
+            typeName: "String",
+            defaultValue: null,
+            interval: null),
+      ],
+      "null");
+
+  @override
+  NavigationData update(String name, String value) {
+    return NavigationData(
+      destination: "destination" != name ? destination : value,
+    );
+  }
+
+  List<Object?> get props => [destination];
+  @override
+  String toString() {
+    final buf = StringBuffer();
+
+    buf.writeln("NavigationData(");
+    buf.writeln("	destination = $destination");
+    buf.writeln(")");
+
+    return buf.toString();
+  }
+}

--- a/lib/widgets/map/map_view.dart
+++ b/lib/widgets/map/map_view.dart
@@ -26,7 +26,7 @@ import 'package:flutter_map/flutter_map.dart'
 import 'package:latlong2/latlong.dart';
 import 'package:mbtiles/mbtiles.dart';
 import 'package:vector_map_tiles/vector_map_tiles.dart'
-    show TileProviders, VectorTileLayer;
+    show TileProviders, VectorTileLayer, VectorTileProvider;
 import 'package:vector_map_tiles_mbtiles/vector_map_tiles_mbtiles.dart'
     show MbTilesVectorTileProvider;
 import 'package:vector_tile_renderer/vector_tile_renderer.dart' show Theme;
@@ -97,7 +97,7 @@ class _OnlineMapViewState extends State<OnlineMapView>
 class OfflineMapView extends StatefulWidget {
   final MapController mapController;
   final Theme theme;
-  final MbTiles mbTiles;
+  final VectorTileProvider tiles;
   final LatLng position;
   final double orientation;
   final void Function(TickerProvider)? mapReady;
@@ -110,7 +110,7 @@ class OfflineMapView extends StatefulWidget {
     super.key,
     required this.mapController,
     required this.theme,
-    required this.mbTiles,
+    required this.tiles,
     required this.position,
     required this.orientation,
     this.setDestination,
@@ -294,10 +294,7 @@ class _OfflineMapViewState extends State<OfflineMapView>
         VectorTileLayer(
           theme: widget.theme,
           tileProviders: TileProviders({
-            'versatiles-shortbread': MbTilesVectorTileProvider(
-              mbtiles: widget.mbTiles,
-              silenceTileNotFound: true,
-            ),
+            'versatiles-shortbread': widget.tiles,
           }),
           maximumZoom: 20,
           fileCacheTtl: const Duration(seconds: 1),


### PR DESCRIPTION
This adds a background isolate that owns the mbtiles database, which allows the synchronize database queries to be run outside of the UI thread.

Also, the map cubit will now react to changes in redis to determine the destination. That should make it possible to set the destination through a cloud command.

```
HSET navigation destination "52.5401299,13.280386"
PUBLISH navigation destination
```