### PR TITLE
feat: Create and add BluetoothPinCodeOverlay to MainScreen

### DIFF
--- a/lib/screens/cluster_screen.dart
+++ b/lib/screens/cluster_screen.dart
@@ -33,8 +33,6 @@ class ClusterScreen extends StatefulWidget {
 
 class _ClusterScreenState extends State<ClusterScreen> {
   String? _errorMessage;
-  Timer? _reconnectTimer;
-  String? _bluetoothPinCode;
 
   // Track previous odometer values for animation
   double _previousTrip = 0.0;
@@ -59,7 +57,6 @@ class _ClusterScreenState extends State<ClusterScreen> {
 
   @override
   void dispose() {
-    _reconnectTimer?.cancel();
     super.dispose();
   }
 
@@ -67,8 +64,7 @@ class _ClusterScreenState extends State<ClusterScreen> {
   Widget build(BuildContext context) {
     final ThemeState(:theme, :isDark) = ThemeCubit.watch(context);
 
-    final (odometer, powerOutput) =
-        EngineSync.select(context, (data) => (data.odometer, data.powerOutput));
+    final (odometer, powerOutput) = EngineSync.select(context, (data) => (data.odometer, data.powerOutput));
     final trip = TripCubit.watch(context);
 
     // Store current odometer values before update
@@ -144,32 +140,10 @@ class _ClusterScreenState extends State<ClusterScreen> {
               left: 0,
               right: 0,
               child: Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                 color: Colors.red.withOpacity(0.8),
                 child: Text(
                   _errorMessage!,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontWeight: FontWeight.bold,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-              ),
-            ),
-
-          // Bluetooth pin code notification
-          if (_bluetoothPinCode != null)
-            Positioned(
-              bottom: 16,
-              left: 0,
-              right: 0,
-              child: Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                color: Colors.blue.withOpacity(0.8),
-                child: Text(
-                  'Bluetooth Pin Code: $_bluetoothPinCode',
                   style: const TextStyle(
                     color: Colors.white,
                     fontWeight: FontWeight.bold,

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import '../cubits/mdb_cubits.dart';
 import '../cubits/menu_cubit.dart';
 import '../cubits/screen_cubit.dart';
+import '../widgets/bluetooth_pin_code_overlay.dart';
 import '../widgets/general/control_gestures_detector.dart';
 import '../widgets/menu/menu_overlay.dart';
 import '../widgets/shutdown/shutdown_overlay.dart';
@@ -41,6 +42,9 @@ class MainScreen extends StatelessWidget {
 
           // Shutdown animation overlay
           ShutdownOverlay(),
+
+          // Bluetooth pin code overlay
+          BluetoothPinCodeOverlay(),
         ],
       ),
     );

--- a/lib/widgets/bluetooth_pin_code_overlay.dart
+++ b/lib/widgets/bluetooth_pin_code_overlay.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'dart:ui';
+
+import '../cubits/mdb_cubits.dart';
+import '../state/bluetooth.dart';
+
+class BluetoothPinCodeOverlay extends StatefulWidget {
+  const BluetoothPinCodeOverlay({super.key});
+
+  @override
+  State<BluetoothPinCodeOverlay> createState() => _BluetoothPinCodeOverlayState();
+}
+
+class _BluetoothPinCodeOverlayState extends State<BluetoothPinCodeOverlay> {
+  Timer? _pinCodeTimer;
+  String? _bluetoothPinCode;
+
+  @override
+  void dispose() {
+    _pinCodeTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<BluetoothSync, BluetoothData>(
+      listener: (context, bluetoothState) {
+        if (bluetoothState.pinCode.isNotEmpty && _bluetoothPinCode != bluetoothState.pinCode) {
+          setState(() {
+            _bluetoothPinCode = bluetoothState.pinCode;
+          });
+          // Start a timer to clear the pin code after a delay
+          _pinCodeTimer?.cancel(); // Cancel previous timer if any
+          _pinCodeTimer = Timer(const Duration(seconds: 30), () {
+            setState(() {
+              _bluetoothPinCode = null;
+            });
+          });
+        } else if (bluetoothState.pinCode.isEmpty && _bluetoothPinCode != null) {
+          setState(() {
+            _bluetoothPinCode = null;
+          });
+          _pinCodeTimer?.cancel(); // Cancel timer if pin code is cleared externally
+        }
+      },
+      child: _bluetoothPinCode != null
+          ? Positioned(
+              bottom: 0,
+              left: 0,
+              right: 0,
+              child: Container(
+                height: MediaQuery.of(context).size.height * 0.20,
+                color: Colors.blue.withOpacity(0.8),
+                alignment: Alignment.center,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const SizedBox(height: 8), // Add some spacing
+                    const Text(
+                      'Use this code to pair your device',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 20,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    Text(
+                      '$_bluetoothPinCode',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 80,
+                        letterSpacing: 14,
+                        height: 1.0,
+                        fontFeatures: [FontFeature.tabularFigures()],
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            )
+          : Container(), // Return an empty container when pin code is null
+    );
+  }
+}


### PR DESCRIPTION
I refactored the BLE pin code display to work across all screens by creating a dedicated BluetoothPinCodeOverlay widget. The previous implementation in ClusterScreen has been removed. The new BluetoothPinCodeOverlay listens to the BluetoothSync cubit and displays the pin code when available, with a 30-second timer to hide it automatically. This ensures the pin code is visible regardless of the currently active screen.