### PR TITLE
feat: Add OTA update progress overlay

### DIFF
--- a/lib/cubits/all.dart
+++ b/lib/cubits/all.dart
@@ -28,4 +28,5 @@ final List<SingleChildWidget> allCubits = [
   BlocProvider(create: MenuCubit.create),
   BlocProvider(create: AddressCubit.create),
   BlocProvider(create: ShutdownCubit.create),
+  BlocProvider(create: OtaSync.create),
 ];

--- a/lib/cubits/mdb_cubits.dart
+++ b/lib/cubits/mdb_cubits.dart
@@ -12,46 +12,37 @@ import '../state/vehicle.dart';
 import 'syncable_cubit.dart';
 
 class EngineSync extends SyncableCubit<EngineData> {
-  static EngineData watch(BuildContext context) =>
-      context.watch<EngineSync>().state;
+  static EngineData watch(BuildContext context) => context.watch<EngineSync>().state;
 
-  static EngineSync create(BuildContext context) =>
-      EngineSync(RepositoryProvider.of<MDBRepository>(context))..start();
+  static EngineSync create(BuildContext context) => EngineSync(RepositoryProvider.of<MDBRepository>(context))..start();
 
   static T select<T>(BuildContext context, T Function(EngineData) selector) =>
       selector(context.select((EngineSync e) => e.state));
 
-  EngineSync(MDBRepository repo)
-      : super(redisRepository: repo, initialState: EngineData());
+  EngineSync(MDBRepository repo) : super(redisRepository: repo, initialState: EngineData());
 }
 
 class VehicleSync extends SyncableCubit<VehicleData> {
-  static VehicleData watch(BuildContext context) =>
-      context.watch<VehicleSync>().state;
+  static VehicleData watch(BuildContext context) => context.watch<VehicleSync>().state;
 
   static VehicleSync create(BuildContext context) =>
       VehicleSync(RepositoryProvider.of<MDBRepository>(context))..start();
 
-  VehicleSync(MDBRepository repo)
-      : super(redisRepository: repo, initialState: VehicleData());
+  VehicleSync(MDBRepository repo) : super(redisRepository: repo, initialState: VehicleData());
 
   void toggleHazardLights() {
-    final command = state.blinkerState == BlinkerState.both
-        ? BlinkerState.off
-        : BlinkerState.both;
+    final command = state.blinkerState == BlinkerState.both ? BlinkerState.off : BlinkerState.both;
 
     super.redisRepository.push("scooter:blinker", command.name);
   }
 }
 
 class BatterySync extends SyncableCubit<BatteryData> {
-  BatterySync(MDBRepository repo, String id)
-      : super(redisRepository: repo, initialState: BatteryData(id: id));
+  BatterySync(MDBRepository repo, String id) : super(redisRepository: repo, initialState: BatteryData(id: id));
 }
 
 class Battery1Sync extends BatterySync {
-  static BatteryData watch(BuildContext context) =>
-      context.watch<Battery1Sync>().state;
+  static BatteryData watch(BuildContext context) => context.watch<Battery1Sync>().state;
 
   static Battery1Sync create(BuildContext context) =>
       Battery1Sync(RepositoryProvider.of<MDBRepository>(context))..start();
@@ -60,8 +51,7 @@ class Battery1Sync extends BatterySync {
 }
 
 class Battery2Sync extends BatterySync {
-  static BatteryData watch(BuildContext context) =>
-      context.watch<Battery2Sync>().state;
+  static BatteryData watch(BuildContext context) => context.watch<Battery2Sync>().state;
 
   static Battery2Sync create(BuildContext context) =>
       Battery2Sync(RepositoryProvider.of<MDBRepository>(context))..start();
@@ -70,44 +60,44 @@ class Battery2Sync extends BatterySync {
 }
 
 class BluetoothSync extends SyncableCubit<BluetoothData> {
-  static BluetoothData watch(BuildContext context) =>
-      context.watch<BluetoothSync>().state;
+  static BluetoothData watch(BuildContext context) => context.watch<BluetoothSync>().state;
 
   static BluetoothSync create(BuildContext context) =>
       BluetoothSync(RepositoryProvider.of<MDBRepository>(context))..start();
 
-  BluetoothSync(MDBRepository repo)
-      : super(redisRepository: repo, initialState: BluetoothData());
+  BluetoothSync(MDBRepository repo) : super(redisRepository: repo, initialState: BluetoothData());
 }
 
 class GpsSync extends SyncableCubit<GpsData> {
   static GpsData watch(BuildContext context) => context.watch<GpsSync>().state;
 
-  static GpsSync create(BuildContext context) =>
-      GpsSync(RepositoryProvider.of<MDBRepository>(context))..start();
+  static GpsSync create(BuildContext context) => GpsSync(RepositoryProvider.of<MDBRepository>(context))..start();
 
-  GpsSync(MDBRepository repo)
-      : super(redisRepository: repo, initialState: GpsData());
+  GpsSync(MDBRepository repo) : super(redisRepository: repo, initialState: GpsData());
 }
 
 class InternetSync extends SyncableCubit<InternetData> {
-  static InternetData watch(BuildContext context) =>
-      context.watch<InternetSync>().state;
+  static InternetData watch(BuildContext context) => context.watch<InternetSync>().state;
 
   static InternetSync create(BuildContext context) =>
       InternetSync(RepositoryProvider.of<MDBRepository>(context))..start();
 
-  InternetSync(MDBRepository repo)
-      : super(redisRepository: repo, initialState: InternetData());
+  InternetSync(MDBRepository repo) : super(redisRepository: repo, initialState: InternetData());
 }
 
 class NavigationSync extends SyncableCubit<NavigationData> {
-  static NavigationData watch(BuildContext context) =>
-      context.watch<NavigationSync>().state;
+  static NavigationData watch(BuildContext context) => context.watch<NavigationSync>().state;
 
   static NavigationSync create(BuildContext context) =>
       NavigationSync(RepositoryProvider.of<MDBRepository>(context))..start();
 
-  NavigationSync(MDBRepository repo)
-      : super(redisRepository: repo, initialState: NavigationData());
+  NavigationSync(MDBRepository repo) : super(redisRepository: repo, initialState: NavigationData());
+}
+
+class OtaSync extends SyncableCubit<OtaData> {
+  static OtaData watch(BuildContext context) => context.watch<OtaSync>().state;
+
+  static OtaSync create(BuildContext context) => OtaSync(RepositoryProvider.of<MDBRepository>(context))..start();
+
+  OtaSync(MDBRepository repo) : super(redisRepository: repo, initialState: OtaData());
 }

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -5,6 +5,7 @@ import '../cubits/mdb_cubits.dart';
 import '../cubits/menu_cubit.dart';
 import '../cubits/screen_cubit.dart';
 import '../widgets/bluetooth_pin_code_overlay.dart';
+import '../widgets/ota_update_overlay.dart';
 import '../widgets/general/control_gestures_detector.dart';
 import '../widgets/menu/menu_overlay.dart';
 import '../widgets/shutdown/shutdown_overlay.dart';
@@ -45,6 +46,9 @@ class MainScreen extends StatelessWidget {
 
           // Bluetooth pin code overlay
           BluetoothPinCodeOverlay(),
+
+          // OTA update overlay
+          OtaUpdateOverlay(),
         ],
       ),
     );

--- a/lib/state/ota.dart
+++ b/lib/state/ota.dart
@@ -1,0 +1,14 @@
+import '../builders/sync/annotations.dart';
+import '../builders/sync/settings.dart';
+
+part 'ota.g.dart';
+
+@StateClass("ota", Duration(seconds: 1))
+class OtaData with $OtaData {
+  @StateField(name: "status", defaultValue: "unknown")
+  String otaStatus;
+
+  OtaData({
+    this.otaStatus = "none",
+  });
+}

--- a/lib/state/ota.g.dart
+++ b/lib/state/ota.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ota.dart';
+
+// **************************************************************************
+// StateGenerator
+// **************************************************************************
+
+abstract mixin class $OtaData implements Syncable<OtaData> {
+  String get otaStatus;
+  get syncSettings => SyncSettings(
+      "ota",
+      Duration(microseconds: 1000000),
+      [
+        SyncFieldSettings(
+            name: "otaStatus",
+            variable: "status",
+            type: SyncFieldType.string,
+            typeName: "String",
+            defaultValue: "unknown",
+            interval: null),
+      ],
+      "null");
+
+  @override
+  OtaData update(String name, String value) {
+    return OtaData(
+      otaStatus: "status" != name ? otaStatus : value,
+    );
+  }
+
+  List<Object?> get props => [otaStatus];
+  @override
+  String toString() {
+    final buf = StringBuffer();
+
+    buf.writeln("OtaData(");
+    buf.writeln("	otaStatus = $otaStatus");
+    buf.writeln(")");
+
+    return buf.toString();
+  }
+}

--- a/lib/widgets/ota_update_overlay.dart
+++ b/lib/widgets/ota_update_overlay.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../cubits/mdb_cubits.dart'; // Assuming OTA status comes from MDB
+import '../state/vehicle.dart'; // Assuming scooter state comes from Vehicle state
+import '../state/enums.dart'; // Assuming scooter state enum is here
+import '../state/ota.dart'; // Import OtaData from its new location
+import '../state/vehicle.dart'; // Import VehicleData
+
+// Define possible OTA update states
+enum OtaStatus {
+  initializing,
+  checkingUpdates,
+  checkingUpdateError,
+  deviceUpdated,
+  waitingDashboard,
+  downloadingUpdates,
+  downloadingUpdateError,
+  installingUpdates,
+  installingUpdateError,
+  installationCompleteWaitingDashboardReboot,
+  installationCompleteWaitingReboot,
+  unknown,
+  none, // Add a 'none' state for when no update is in progress
+}
+
+// Helper function to map string status from MDB to OtaStatus enum
+OtaStatus mapOtaStatus(String? status) {
+  switch (status) {
+    case 'initializing':
+      return OtaStatus.initializing;
+    case 'checking-updates':
+      return OtaStatus.checkingUpdates;
+    case 'checking-update-error':
+      return OtaStatus.checkingUpdateError;
+    case 'device-updated':
+      return OtaStatus.deviceUpdated;
+    case 'waiting-dashboard':
+      return OtaStatus.waitingDashboard;
+    case 'downloading-updates':
+      return OtaStatus.downloadingUpdates;
+    case 'downloading-update-error':
+      return OtaStatus.downloadingUpdateError;
+    case 'installing-updates':
+      return OtaStatus.installingUpdates;
+    case 'installing-update-error':
+      return OtaStatus.installingUpdateError;
+    case 'installation-complete-waiting-dashboard-reboot':
+      return OtaStatus.installationCompleteWaitingDashboardReboot;
+    case 'installation-complete-waiting-reboot':
+      return OtaStatus.installationCompleteWaitingReboot;
+    case 'unknown':
+      return OtaStatus.unknown;
+    default:
+      return OtaStatus.none;
+  }
+}
+
+// Helper function to get display text for OTA status
+String getOtaStatusText(OtaStatus status) {
+  switch (status) {
+    case OtaStatus.initializing:
+      return 'Initializing update...';
+    case OtaStatus.checkingUpdates:
+      return 'Checking for updates...';
+    case OtaStatus.checkingUpdateError:
+      return 'Update check failed.';
+    case OtaStatus.deviceUpdated:
+      return 'Device updated.';
+    case OtaStatus.waitingDashboard:
+      return 'Waiting for dashboard...';
+    case OtaStatus.downloadingUpdates:
+      return 'Downloading updates...';
+    case OtaStatus.downloadingUpdateError:
+      return 'Download failed.';
+    case OtaStatus.installingUpdates:
+      return 'Installing updates...';
+    case OtaStatus.installingUpdateError:
+      return 'Installation failed.';
+    case OtaStatus.installationCompleteWaitingDashboardReboot:
+      return 'Installation complete, waiting for dashboard reboot...';
+    case OtaStatus.installationCompleteWaitingReboot:
+      return 'Installation complete, waiting for reboot...';
+    case OtaStatus.unknown:
+      return 'Unknown update status.';
+    case OtaStatus.none:
+      return ''; // Should not be displayed
+  }
+}
+
+class OtaUpdateOverlay extends StatelessWidget {
+  const OtaUpdateOverlay({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // Watch the vehicle state to determine scooter mode
+    final vehicleState = VehicleSync.watch(context);
+    final isReadyToDrive = vehicleState.state == ScooterState.readyToDrive; // Corrected access
+
+    // Watch the OTA status from MDB data
+    final otaStatusString = OtaSync.watch(context).otaStatus;
+    final otaStatus = mapOtaStatus(otaStatusString);
+
+    // Determine if the overlay should be shown based on scooter mode and status
+    bool showOverlay = false;
+    final isParked = vehicleState.state == ScooterState.parked;
+
+    if (isReadyToDrive) {
+      // In ready-to-drive mode, show only for downloading, installing, and their errors
+      showOverlay = otaStatus == OtaStatus.downloadingUpdates ||
+          otaStatus == OtaStatus.downloadingUpdateError ||
+          otaStatus == OtaStatus.installingUpdates ||
+          otaStatus == OtaStatus.installingUpdateError;
+    } else if (isParked) {
+      // In parked mode, hide for specific statuses
+      showOverlay = !(otaStatus == OtaStatus.unknown ||
+          otaStatus == OtaStatus.initializing ||
+          otaStatus == OtaStatus.checkingUpdates);
+    } else {
+      // In other non-ready-to-drive modes (like standby and off), show for all statuses except deviceUpdated and none
+      showOverlay = otaStatus != OtaStatus.deviceUpdated && otaStatus != OtaStatus.none;
+    }
+
+    if (!showOverlay) {
+      return Container(); // Don't show anything if overlay is not needed
+    }
+
+    final statusText = getOtaStatusText(otaStatus);
+
+    if (isReadyToDrive) {
+      // Minimal overlay at the bottom for ready-to-drive mode
+      return Positioned(
+        bottom: 16, // Tiny bit of padding
+        left: 0,
+        right: 0,
+        child: Center(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8), // Tiny bit of padding
+            decoration: BoxDecoration(
+              color: Colors.black.withOpacity(0.7), // Semi-transparent background
+              borderRadius: BorderRadius.circular(8), // Rounded corners
+            ),
+            child: Text(
+              statusText,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 16, // Font size 16 or so
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      );
+    } else {
+      // Full-screen overlay with spinner for standby mode
+      return Container(
+        color: Colors.black.withOpacity(0.8), // Dark semi-transparent background
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const CircularProgressIndicator(
+                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+              ),
+              const SizedBox(height: 20),
+              Text(
+                statusText,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+  }
+}


### PR DESCRIPTION
Implements an overlay to display the status of OTA updates.

The overlay's appearance and visibility are conditional based on the scooter's state and the current OTA status:

- In `ready-to-drive` mode, a minimal, bottom-anchored overlay is shown only for downloading, installing, and related error statuses: https://github.com/user-attachments/assets/24ffeded-82a1-43bf-88a5-fedc76bbaa0c
- In `parked` mode, a full-screen overlay with a spinner is shown for most statuses, but hidden for `unknown`, `initializing`, and `checking-updates`.
- In other modes (e.g., `standBy`), a full-screen overlay with a spinner is shown for most statuses: https://github.com/user-attachments/assets/79451b5e-8923-4e3b-b4c3-b6211182028a

Introduces `OtaData` state class and `OtaSync` cubit to synchronize the `ota:status` from the "ota" Redis channel (see `lib/state/ota.dart`).

Fixes #37.