### PR TITLE
feat: live street name and speed limit from vector tiles

### DIFF
--- a/lib/cubits/all.dart
+++ b/lib/cubits/all.dart
@@ -35,6 +35,7 @@ final List<SingleChildWidget> allCubits = [
             gpsStream: context.read<GpsSync>().stream,
             navigationSync: context.read<NavigationSync>(),
             vehicleStream: context.read<VehicleSync>().stream,
+            tilesRepository: context.read(),
           )),
   BlocProvider(create: SpeedLimitSync.create),
   BlocProvider(create: SettingsSync.create),

--- a/lib/cubits/map_cubit.dart
+++ b/lib/cubits/map_cubit.dart
@@ -46,7 +46,7 @@ class MapCubit extends Cubit<MapState> {
   static const double _zoomMax = 17.5; // Maximum zoom for complex turns (~150m look-ahead)
 
   // Vehicle positioning - public so VehicleIndicator can use the same value
-  static const Offset mapCenterOffset = Offset(0, 140); // Vehicle positioned toward bottom for better look-ahead
+  static const Offset mapCenterOffset = Offset(0, 120); // Vehicle positioned toward bottom for better look-ahead (reduced for street name display)
 
   MapTransformAnimator? _transformAnimator;
   final bool _mapLocked = false;

--- a/lib/cubits/navigation_cubit.dart
+++ b/lib/cubits/navigation_cubit.dart
@@ -1,9 +1,13 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:mbtiles/mbtiles.dart';
+import 'package:vector_tile/vector_tile.dart';
 
 import '../config.dart';
+import '../repositories/tiles_repository.dart';
 import '../routing/models.dart';
 import '../routing/route_helpers.dart';
 import '../routing/valhalla.dart';
@@ -19,11 +23,14 @@ class NavigationCubit extends Cubit<NavigationState> {
   late final StreamSubscription<NavigationData> _navigationSub;
   late final StreamSubscription<VehicleData> _vehicleSub;
   final NavigationSync _navigationSync;
+  final TilesRepository _tilesRepository;
   VehicleData _vehicleData;
+  MbTiles? _mbTiles;
 
   static const double _arrivalProximityMeters = 25.0;
   static const double _offRouteTolerance = 40.0; // meters
   DateTime? _lastReroute;
+  DateTime? _lastStreetLog;
   LatLng? _currentPosition;
 
   final distanceCalculator = Distance();
@@ -32,7 +39,9 @@ class NavigationCubit extends Cubit<NavigationState> {
     required Stream<GpsData> gpsStream,
     required NavigationSync navigationSync,
     required Stream<VehicleData> vehicleStream,
+    required TilesRepository tilesRepository,
   })  : _navigationSync = navigationSync,
+        _tilesRepository = tilesRepository,
         _vehicleData = VehicleData(), // Initialize with a default or initial value
         super(const NavigationState()) {
     _gpsSub = gpsStream.listen(_onGpsData);
@@ -41,10 +50,20 @@ class NavigationCubit extends Cubit<NavigationState> {
 
     // Process initial navigation data if available
     _processInitialNavigationData();
+
+    // Load MBTiles for street property logging
+    _loadMbTiles();
   }
 
   void _onVehicleData(VehicleData data) {
     _vehicleData = data;
+  }
+
+  Future<void> _loadMbTiles() async {
+    final tiles = await _tilesRepository.getMbTiles();
+    if (tiles is Success) {
+      _mbTiles = tiles.mbTiles;
+    }
   }
 
   @override
@@ -64,6 +83,7 @@ class NavigationCubit extends Cubit<NavigationState> {
       await clearNavigation();
     }
 
+    _mbTiles?.dispose();
     _gpsSub.cancel();
     _navigationSub.cancel();
     _vehicleSub.cancel();
@@ -205,6 +225,9 @@ class NavigationCubit extends Cubit<NavigationState> {
     if (data.hasRecentFix) {
       final position = LatLng(data.latitude, data.longitude);
       _currentPosition = position;
+
+      // Log nearest street properties
+      _logNearestStreetProperties(position);
     } else {
       _currentPosition = null;
     }
@@ -367,5 +390,164 @@ class NavigationCubit extends Cubit<NavigationState> {
         error: errorMsg,
       ));
     }
+  }
+
+  void _logNearestStreetProperties(LatLng position) {
+    // Throttle logging to every 3 seconds
+    if (_lastStreetLog != null && DateTime.now().difference(_lastStreetLog!) < const Duration(seconds: 3)) {
+      return;
+    }
+
+    if (_mbTiles == null) {
+      return;
+    }
+
+    _lastStreetLog = DateTime.now();
+
+    // If we're navigating and on-route, use the snapped position (more accurate)
+    final queryPosition = (state.route != null && state.snappedPosition != null && !(state.isOffRoute ?? false))
+        ? state.snappedPosition!
+        : position;
+
+    try {
+      // Convert position to tile coordinates (use zoom 14 for detailed street data)
+      const zoom = 14;
+      final tileX = _lonToTileX(queryPosition.longitude, zoom);
+      final tileY = _latToTileYTMS(queryPosition.latitude, zoom);
+
+      // Get the tile
+      final tileData = _mbTiles!.getTile(x: tileX, y: tileY, z: zoom);
+      if (tileData == null) {
+        return;
+      }
+
+      // Parse vector tile
+      final vectorTile = VectorTile.fromBytes(bytes: tileData);
+      final streetsLayer = vectorTile.layers.firstWhere(
+        (layer) => layer.name == 'streets',
+        orElse: () => throw StateError('No streets layer'),
+      );
+
+      if (streetsLayer.features.isEmpty) {
+        return;
+      }
+
+      // Street types that are actual roads (not pedestrian ways)
+      const roadTypes = {
+        'motorway', 'trunk', 'primary', 'secondary', 'tertiary',
+        'unclassified', 'residential', 'living_street', 'service'
+      };
+
+      // Find nearest actual road (not footway/path/etc)
+      double minDistance = double.infinity;
+      VectorTileFeature? nearestFeature;
+
+      for (var feature in streetsLayer.features) {
+        // Decode geometry (which also decodes properties)
+        final geometry = feature.decodeGeometry();
+
+        // Check if this is an actual road (not footway/path/cycleway/etc)
+        if (feature.properties != null) {
+          final kind = feature.properties!['kind']?.value.toString();
+          if (kind == null || !roadTypes.contains(kind)) {
+            continue; // Skip pedestrian ways
+          }
+        }
+
+        if (geometry is GeometryLineString) {
+          final coords = geometry.coordinates;
+
+          // Convert all tile coordinates to geographic coordinates
+          final points = <LatLng>[];
+          for (var point in coords) {
+            // Vector tiles use XYZ (Y=0 at top), but MBTiles uses TMS (Y=0 at bottom)
+            // So we need to flip the Y coordinate within the tile
+            final n = math.pow(2.0, zoom).toDouble();
+            final extent = streetsLayer.extent;
+            final lon = (tileX + point[0] / extent) / n * 360.0 - 180.0;
+            final y = 1 - (tileY + 1 - point[1] / extent) / n;  // Flip Y within tile for TMS
+            final z = math.pi * (1 - 2 * y);
+            final latRad = math.atan((math.exp(z) - math.exp(-z)) / 2);
+            final lat = latRad * 180.0 / math.pi;
+            points.add(LatLng(lat, lon));
+          }
+
+          // Check distance to each line segment
+          for (var i = 0; i < points.length - 1; i++) {
+            final segmentStart = points[i];
+            final segmentEnd = points[i + 1];
+
+            final distance = _distanceToSegment(queryPosition, segmentStart, segmentEnd);
+
+            if (distance < minDistance) {
+              minDistance = distance;
+              nearestFeature = feature;
+            }
+          }
+        }
+      }
+
+      if (nearestFeature != null && nearestFeature.properties != null) {
+        final props = nearestFeature.properties!;
+        final name = props['name']?.value.toString();
+        final kind = props['kind']?.value.toString();
+        final maxspeed = props['maxspeed']?.value.toString();
+
+        final displayName = name ?? '';
+        final displayKind = kind ?? '';
+        final displaySpeed = maxspeed ?? '';
+
+        // Update state with current street data
+        emit(state.copyWith(
+          currentStreetName: displayName.isEmpty ? null : displayName,
+          currentRoadType: displayKind.isEmpty ? null : displayKind,
+          currentSpeedLimit: displaySpeed.isEmpty ? null : displaySpeed,
+        ));
+      }
+    } catch (e) {
+      // Silently handle errors
+    }
+  }
+
+  int _lonToTileX(double lon, int zoom) {
+    return ((lon + 180) / 360 * (1 << zoom)).floor();
+  }
+
+  int _latToTileYTMS(double lat, int zoom) {
+    final latRad = lat * (math.pi / 180);
+    final n = math.pow(2.0, zoom).toDouble();
+    final y = (1.0 - math.log(math.tan(latRad) + 1.0 / math.cos(latRad)) / math.pi) / 2.0 * n;
+    final tmsY = (n - 1 - y).floor();
+    return tmsY + 1;  // MBTiles uses 1-indexed TMS
+  }
+
+  /// Calculate distance from point to line segment
+  double _distanceToSegment(LatLng point, LatLng segmentStart, LatLng segmentEnd) {
+    // If the segment is actually just a point
+    if (segmentStart.latitude == segmentEnd.latitude &&
+        segmentStart.longitude == segmentEnd.longitude) {
+      return distanceCalculator.as(LengthUnit.Meter, point, segmentStart);
+    }
+
+    // Vector from segment start to end
+    final dx = segmentEnd.longitude - segmentStart.longitude;
+    final dy = segmentEnd.latitude - segmentStart.latitude;
+
+    // Vector from segment start to point
+    final px = point.longitude - segmentStart.longitude;
+    final py = point.latitude - segmentStart.latitude;
+
+    // Project point onto line (parameter t)
+    final t = (px * dx + py * dy) / (dx * dx + dy * dy);
+
+    // Clamp t to [0, 1] to stay on segment
+    final tClamped = t.clamp(0.0, 1.0);
+
+    // Find closest point on segment
+    final closestLat = segmentStart.latitude + tClamped * dy;
+    final closestLon = segmentStart.longitude + tClamped * dx;
+    final closestPoint = LatLng(closestLat, closestLon);
+
+    return distanceCalculator.as(LengthUnit.Meter, point, closestPoint);
   }
 }

--- a/lib/cubits/navigation_state.dart
+++ b/lib/cubits/navigation_state.dart
@@ -30,6 +30,9 @@ abstract class NavigationState with _$NavigationState {
     @Default(false) bool isOffRoute,
     @Default(null) LatLng? snappedPosition,
     @Default([]) List<String> pendingConditions,
+    @Default(null) String? currentStreetName,
+    @Default(null) String? currentRoadType,
+    @Default(null) String? currentSpeedLimit,
   }) = _NavigationState;
 
   bool get isNavigating => status == NavigationStatus.navigating;

--- a/lib/cubits/navigation_state.freezed.dart
+++ b/lib/cubits/navigation_state.freezed.dart
@@ -26,6 +26,9 @@ mixin _$NavigationState {
   bool get isOffRoute;
   LatLng? get snappedPosition;
   List<String> get pendingConditions;
+  String? get currentStreetName;
+  String? get currentRoadType;
+  String? get currentSpeedLimit;
 
   /// Create a copy of NavigationState
   /// with the given fields replaced by the non-null parameter values.
@@ -58,7 +61,13 @@ mixin _$NavigationState {
             (identical(other.snappedPosition, snappedPosition) ||
                 other.snappedPosition == snappedPosition) &&
             const DeepCollectionEquality()
-                .equals(other.pendingConditions, pendingConditions));
+                .equals(other.pendingConditions, pendingConditions) &&
+            (identical(other.currentStreetName, currentStreetName) ||
+                other.currentStreetName == currentStreetName) &&
+            (identical(other.currentRoadType, currentRoadType) ||
+                other.currentRoadType == currentRoadType) &&
+            (identical(other.currentSpeedLimit, currentSpeedLimit) ||
+                other.currentSpeedLimit == currentSpeedLimit));
   }
 
   @override
@@ -74,11 +83,14 @@ mixin _$NavigationState {
       distanceFromRoute,
       isOffRoute,
       snappedPosition,
-      const DeepCollectionEquality().hash(pendingConditions));
+      const DeepCollectionEquality().hash(pendingConditions),
+      currentStreetName,
+      currentRoadType,
+      currentSpeedLimit);
 
   @override
   String toString() {
-    return 'NavigationState(route: $route, currentInstruction: $currentInstruction, upcomingInstructions: $upcomingInstructions, destination: $destination, status: $status, error: $error, distanceToDestination: $distanceToDestination, distanceFromRoute: $distanceFromRoute, isOffRoute: $isOffRoute, snappedPosition: $snappedPosition, pendingConditions: $pendingConditions)';
+    return 'NavigationState(route: $route, currentInstruction: $currentInstruction, upcomingInstructions: $upcomingInstructions, destination: $destination, status: $status, error: $error, distanceToDestination: $distanceToDestination, distanceFromRoute: $distanceFromRoute, isOffRoute: $isOffRoute, snappedPosition: $snappedPosition, pendingConditions: $pendingConditions, currentStreetName: $currentStreetName, currentRoadType: $currentRoadType, currentSpeedLimit: $currentSpeedLimit)';
   }
 }
 
@@ -99,7 +111,10 @@ abstract mixin class $NavigationStateCopyWith<$Res> {
       double distanceFromRoute,
       bool isOffRoute,
       LatLng? snappedPosition,
-      List<String> pendingConditions});
+      List<String> pendingConditions,
+      String? currentStreetName,
+      String? currentRoadType,
+      String? currentSpeedLimit});
 
   $RouteCopyWith<$Res>? get route;
   $RouteInstructionCopyWith<$Res>? get currentInstruction;
@@ -129,6 +144,9 @@ class _$NavigationStateCopyWithImpl<$Res>
     Object? isOffRoute = null,
     Object? snappedPosition = freezed,
     Object? pendingConditions = null,
+    Object? currentStreetName = freezed,
+    Object? currentRoadType = freezed,
+    Object? currentSpeedLimit = freezed,
   }) {
     return _then(_self.copyWith(
       route: freezed == route
@@ -175,6 +193,18 @@ class _$NavigationStateCopyWithImpl<$Res>
           ? _self.pendingConditions
           : pendingConditions // ignore: cast_nullable_to_non_nullable
               as List<String>,
+      currentStreetName: freezed == currentStreetName
+          ? _self.currentStreetName
+          : currentStreetName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      currentRoadType: freezed == currentRoadType
+          ? _self.currentRoadType
+          : currentRoadType // ignore: cast_nullable_to_non_nullable
+              as String?,
+      currentSpeedLimit: freezed == currentSpeedLimit
+          ? _self.currentSpeedLimit
+          : currentSpeedLimit // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 
@@ -221,7 +251,10 @@ class _NavigationState extends NavigationState {
       this.distanceFromRoute = 0.0,
       this.isOffRoute = false,
       this.snappedPosition = null,
-      final List<String> pendingConditions = const []})
+      final List<String> pendingConditions = const [],
+      this.currentStreetName = null,
+      this.currentRoadType = null,
+      this.currentSpeedLimit = null})
       : _upcomingInstructions = upcomingInstructions,
         _pendingConditions = pendingConditions,
         super._();
@@ -273,6 +306,16 @@ class _NavigationState extends NavigationState {
     return EqualUnmodifiableListView(_pendingConditions);
   }
 
+  @override
+  @JsonKey()
+  final String? currentStreetName;
+  @override
+  @JsonKey()
+  final String? currentRoadType;
+  @override
+  @JsonKey()
+  final String? currentSpeedLimit;
+
   /// Create a copy of NavigationState
   /// with the given fields replaced by the non-null parameter values.
   @override
@@ -304,7 +347,13 @@ class _NavigationState extends NavigationState {
             (identical(other.snappedPosition, snappedPosition) ||
                 other.snappedPosition == snappedPosition) &&
             const DeepCollectionEquality()
-                .equals(other._pendingConditions, _pendingConditions));
+                .equals(other._pendingConditions, _pendingConditions) &&
+            (identical(other.currentStreetName, currentStreetName) ||
+                other.currentStreetName == currentStreetName) &&
+            (identical(other.currentRoadType, currentRoadType) ||
+                other.currentRoadType == currentRoadType) &&
+            (identical(other.currentSpeedLimit, currentSpeedLimit) ||
+                other.currentSpeedLimit == currentSpeedLimit));
   }
 
   @override
@@ -320,11 +369,14 @@ class _NavigationState extends NavigationState {
       distanceFromRoute,
       isOffRoute,
       snappedPosition,
-      const DeepCollectionEquality().hash(_pendingConditions));
+      const DeepCollectionEquality().hash(_pendingConditions),
+      currentStreetName,
+      currentRoadType,
+      currentSpeedLimit);
 
   @override
   String toString() {
-    return 'NavigationState(route: $route, currentInstruction: $currentInstruction, upcomingInstructions: $upcomingInstructions, destination: $destination, status: $status, error: $error, distanceToDestination: $distanceToDestination, distanceFromRoute: $distanceFromRoute, isOffRoute: $isOffRoute, snappedPosition: $snappedPosition, pendingConditions: $pendingConditions)';
+    return 'NavigationState(route: $route, currentInstruction: $currentInstruction, upcomingInstructions: $upcomingInstructions, destination: $destination, status: $status, error: $error, distanceToDestination: $distanceToDestination, distanceFromRoute: $distanceFromRoute, isOffRoute: $isOffRoute, snappedPosition: $snappedPosition, pendingConditions: $pendingConditions, currentStreetName: $currentStreetName, currentRoadType: $currentRoadType, currentSpeedLimit: $currentSpeedLimit)';
   }
 }
 
@@ -347,7 +399,10 @@ abstract mixin class _$NavigationStateCopyWith<$Res>
       double distanceFromRoute,
       bool isOffRoute,
       LatLng? snappedPosition,
-      List<String> pendingConditions});
+      List<String> pendingConditions,
+      String? currentStreetName,
+      String? currentRoadType,
+      String? currentSpeedLimit});
 
   @override
   $RouteCopyWith<$Res>? get route;
@@ -379,6 +434,9 @@ class __$NavigationStateCopyWithImpl<$Res>
     Object? isOffRoute = null,
     Object? snappedPosition = freezed,
     Object? pendingConditions = null,
+    Object? currentStreetName = freezed,
+    Object? currentRoadType = freezed,
+    Object? currentSpeedLimit = freezed,
   }) {
     return _then(_NavigationState(
       route: freezed == route
@@ -425,6 +483,18 @@ class __$NavigationStateCopyWithImpl<$Res>
           ? _self._pendingConditions
           : pendingConditions // ignore: cast_nullable_to_non_nullable
               as List<String>,
+      currentStreetName: freezed == currentStreetName
+          ? _self.currentStreetName
+          : currentStreetName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      currentRoadType: freezed == currentRoadType
+          ? _self.currentRoadType
+          : currentRoadType // ignore: cast_nullable_to_non_nullable
+              as String?,
+      currentSpeedLimit: freezed == currentSpeedLimit
+          ? _self.currentSpeedLimit
+          : currentSpeedLimit // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -67,8 +67,9 @@ class MapScreen extends StatelessWidget {
                           Expanded(
                             child: _buildWarningIndicators(context),
                           ),
-                          // Center bottom: street name display if available
-                          Expanded(
+                          // Center bottom: street name display
+                          Flexible(
+                            flex: 2,
                             child: _buildStreetNameDisplay(context),
                           ),
                           // Right side: north indicator space (map renders it)
@@ -278,31 +279,28 @@ class MapScreen extends StatelessWidget {
   }
 
   Widget _buildStreetNameDisplay(BuildContext context) {
-    final speedLimitData = SpeedLimitSync.watch(context);
-    final ThemeState(:theme, :isDark) = ThemeCubit.watch(context);
-    
-    if (speedLimitData.roadName.isEmpty) {
+    final roadName = context.select((NavigationCubit c) => c.state.currentStreetName);
+    final ThemeState(:isDark) = ThemeCubit.watch(context);
+
+    if (roadName == null || roadName.isEmpty) {
       return const SizedBox.shrink();
     }
-    
+
     return Center(
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-        decoration: BoxDecoration(
-          color: theme.scaffoldBackgroundColor.withOpacity(0.9),
-          borderRadius: BorderRadius.circular(8),
-          border: Border.all(
-            color: isDark ? Colors.white12 : Colors.black12,
-            width: 1,
-          ),
-        ),
-        child: RoadNameDisplay(
-          textStyle: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.w500,
-            color: isDark ? Colors.white70 : Colors.black54,
-          ),
-        ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          // Allow full width but constrain to screen width
+          return ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 480),
+            child: RoadNameDisplay(
+              textStyle: TextStyle(
+                fontSize: 14,
+                letterSpacing: roadName.length > 20 ? -0.5 : 0,
+                color: isDark ? Colors.white70 : Colors.black87,
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/widgets/indicators/speed_limit_indicator.dart
+++ b/lib/widgets/indicators/speed_limit_indicator.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
 
-import '../../cubits/mdb_cubits.dart';
+import '../../cubits/navigation_cubit.dart';
 
 class SpeedLimitIndicator extends StatelessWidget {
   final double iconSize;
@@ -16,47 +17,37 @@ class SpeedLimitIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final speedLimitData = SpeedLimitSync.watch(context);
+    final speedLimit = context.select((NavigationCubit c) => c.state.currentSpeedLimit);
 
     // Don't show anything if there's no speed limit data
-    if (!speedLimitData.hasSpeedLimit || speedLimitData.iconName.isEmpty) {
+    if (speedLimit == null || speedLimit.isEmpty) {
       return const SizedBox.shrink();
     }
 
-    // If using blank template, overlay text on the icon
-    if (speedLimitData.iconName == "speedlimit_blank") {
-      return Stack(
-        alignment: Alignment.center,
-        children: [
-          // Base icon
-          SvgPicture.asset(
-            'assets/icons/speedlimit_blank.svg',
-            width: iconSize,
-            height: iconSize,
-            colorFilter: iconColor != null ? ColorFilter.mode(iconColor!, BlendMode.srcIn) : null,
-          ),
+    // Use the blank template with custom text overlay
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        // Base icon
+        SvgPicture.asset(
+          'assets/icons/speedlimit_blank.svg',
+          width: iconSize,
+          height: iconSize,
+          colorFilter: iconColor != null ? ColorFilter.mode(iconColor!, BlendMode.srcIn) : null,
+        ),
 
-          // Text overlay
-          // Scale font size proportionally to the icon size (64pt at 144px)
-          Text(
-            speedLimitData.speedLimit,
-            style: GoogleFonts.robotoCondensed(
-              fontWeight: FontWeight.bold,
-              fontSize: iconSize * (64 / 144), // Scale proportionally
-              color: Colors.black,
-            ),
-            textAlign: TextAlign.center,
+        // Text overlay
+        // Scale font size proportionally to the icon size (64pt at 144px)
+        Text(
+          speedLimit,
+          style: GoogleFonts.robotoCondensed(
+            fontWeight: FontWeight.bold,
+            fontSize: iconSize * (64 / 144), // Scale proportionally
+            color: Colors.black,
           ),
-        ],
-      );
-    }
-
-    // For pre-designed icons
-    return SvgPicture.asset(
-      'assets/icons/${speedLimitData.iconName}.svg',
-      width: iconSize,
-      height: iconSize,
-      colorFilter: iconColor != null ? ColorFilter.mode(iconColor!, BlendMode.srcIn) : null,
+          textAlign: TextAlign.center,
+        ),
+      ],
     );
   }
 }
@@ -71,15 +62,16 @@ class RoadNameDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final speedLimitData = SpeedLimitSync.watch(context);
+    final roadName = context.select((NavigationCubit c) => c.state.currentStreetName);
+    final roadType = context.select((NavigationCubit c) => c.state.currentRoadType);
 
     // Don't show anything if there's no road name
-    if (speedLimitData.roadName.isEmpty) {
+    if (roadName == null || roadName.isEmpty) {
       return const SizedBox.shrink();
     }
 
     // Get styling based on German road sign standards for different road types
-    final (Color bgColor, Color textColor, BoxBorder? border) = _getRoadSignStyle(speedLimitData.roadType);
+    final (Color bgColor, Color textColor, BoxBorder? border) = _getRoadSignStyle(roadType ?? '');
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
@@ -89,7 +81,7 @@ class RoadNameDisplay extends StatelessWidget {
         border: border,
       ),
       child: Text(
-        speedLimitData.roadName,
+        roadName,
         style: (textStyle ?? Theme.of(context).textTheme.bodyMedium)?.copyWith(
           color: textColor,
           fontWeight: FontWeight.w500,

--- a/lib/widgets/status_bars/speed_center_widget.dart
+++ b/lib/widgets/status_bars/speed_center_widget.dart
@@ -19,26 +19,35 @@ class SpeedCenterWidget extends StatelessWidget {
     // Get the correct speed based on settings
     final speed = _getDisplaySpeed(engineData, settings);
 
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
+    return Stack(
+      alignment: Alignment.center,
       children: [
-        const SpeedLimitIndicator(iconSize: 36),
-        Text(
-          speed.toStringAsFixed(0),
-          style: TextStyle(
-            fontSize: 48,
-            fontWeight: FontWeight.bold,
-            color: textColor,
-            height: 1.0,
-          ),
+        Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              speed.toStringAsFixed(0),
+              style: TextStyle(
+                fontSize: 48,
+                fontWeight: FontWeight.bold,
+                color: textColor,
+                height: 1.0,
+              ),
+            ),
+            Text(
+              'km/h',
+              style: TextStyle(
+                fontSize: 16,
+                color: isDark ? Colors.white70 : Colors.black54,
+                height: 0.8,
+              ),
+            ),
+          ],
         ),
-        Text(
-          'km/h',
-          style: TextStyle(
-            fontSize: 16,
-            color: isDark ? Colors.white70 : Colors.black54,
-            height: 0.8,
-          ),
+        // Position speed limit to the right of the speed
+        Positioned(
+          right: 0,
+          child: const SpeedLimitIndicator(iconSize: 36),
         ),
       ],
     );


### PR DESCRIPTION
## Summary

- Extract and display current street name, road type, and speed limit from vector tile data
- Query MBTiles streets layer using geometry-based nearest road matching
- Display street name with German road sign styling (blue/yellow/white based on road type)
- Show speed limit as overlay on standardized sign icon
- Gracefully degrades when tiles lack maxspeed property (backwards compatible)

## Implementation

- NavigationCubit queries tiles at zoom 14, filters for actual roads (excludes footways/paths)
- Calculates distance to line segments to find nearest road, handles TMS/XYZ coordinate differences
- Updates NavigationState with currentStreetName, currentRoadType, currentSpeedLimit
- Uses snapped position when on-route for better accuracy
- UI reads from NavigationState instead of separate Redis sync

## Test Plan

- [x] Verify with tiles containing/missing maxspeed property
- [x] Street name updates as vehicle moves
- [x] Speed limit displays correctly
- [x] On-route vs off-route position handling
- [x] Road sign color coding by type
- [x] Long street name layout