### PR TITLE
feat(map): move tile cache to persistent storage

### DIFF
--- a/lib/utils/theme_aware_cache.dart
+++ b/lib/utils/theme_aware_cache.dart
@@ -6,28 +6,28 @@ import 'package:path_provider/path_provider.dart';
 class ThemeAwareCache {
   static Future<Directory> Function() getCacheFolderProvider(String themeMode) {
     return () async {
-      final tempFolder = await getTemporaryDirectory();
-      final cacheDir = Directory('${tempFolder.path}/.vector_map_$themeMode');
-      
+      final appDir = await getApplicationDocumentsDirectory();
+      final cacheDir = Directory('${appDir.path}/maps/cache/$themeMode');
+
       // Ensure directory exists
       if (!await cacheDir.exists()) {
         await cacheDir.create(recursive: true);
       }
-      
+
       return cacheDir;
     };
   }
-  
+
   /// Clear cache for a specific theme
   static Future<void> clearThemeCache(String themeMode) async {
-    final tempFolder = await getTemporaryDirectory();
-    final cacheDir = Directory('${tempFolder.path}/.vector_map_$themeMode');
-    
+    final appDir = await getApplicationDocumentsDirectory();
+    final cacheDir = Directory('${appDir.path}/maps/cache/$themeMode');
+
     if (await cacheDir.exists()) {
       await cacheDir.delete(recursive: true);
     }
   }
-  
+
   /// Clear all theme caches
   static Future<void> clearAllCaches() async {
     await Future.wait([


### PR DESCRIPTION
## Summary

- Move vector map tile cache from temporary directory to `/data/maps/cache/` for persistence across device reboots
- Cache remains theme-separated (`light/` and `dark/` subdirectories)
- Consistent location alongside MBTiles file at `/data/maps/map.mbtiles`

## Changes

**Before:** `{tempDir}/.vector_map_{theme}/` (cleared on reboot)
**After:** `{appDocumentsDir}/maps/cache/{theme}/` (persists across reboots)

On DBC hardware this resolves to:
- `/data/maps/cache/light/`
- `/data/maps/cache/dark/`

## Test plan

- [ ] Verify cache directory is created on first map load
- [ ] Confirm tiles are cached and reused on subsequent map views
- [ ] Test cache persists after app restart
- [ ] Verify theme switching maintains separate caches
- [ ] Check cache clearing functionality still works