### PR TITLE
fix(map): use theme background color for tile loading

### DIFF
--- a/lib/widgets/map/map_view.dart
+++ b/lib/widgets/map/map_view.dart
@@ -358,6 +358,7 @@ class _OnlineMapViewState extends State<OnlineMapView> with TickerProviderStateM
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    final theme = Theme.of(context);
     final tileUrl = isDark
         ? 'https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png'
         : 'https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png';
@@ -371,6 +372,7 @@ class _OnlineMapViewState extends State<OnlineMapView> with TickerProviderStateM
             maxZoom: 18,
             initialCenter: widget.position,
             initialZoom: 17,
+            backgroundColor: theme.scaffoldBackgroundColor,
           ),
           mapController: widget.mapController,
           children: [
@@ -543,6 +545,7 @@ class _OfflineMapViewState extends State<OfflineMapView> with TickerProviderStat
   @override
   Widget build(BuildContext context) {
     final routeLayer = _routeLayer(context);
+    final theme = Theme.of(context);
 
     return Stack(
       children: [
@@ -555,6 +558,7 @@ class _OfflineMapViewState extends State<OfflineMapView> with TickerProviderStat
             maxZoom: 20,
             initialCenter: widget.position,
             initialZoom: 17,
+            backgroundColor: theme.scaffoldBackgroundColor,
             onTap: (tapPosition, latLng) {
               // Set GPS location via MDBRepository in simulator mode
               final mdbRepo = RepositoryProvider.of<MDBRepository>(context);


### PR DESCRIPTION
## Summary
Sets MapOptions backgroundColor to theme.scaffoldBackgroundColor to replace the default light grey background with theme-aware colors.

## Changes
- Applies to both online (TileLayer) and offline (VectorTileLayer) map views
- Uses theme.scaffoldBackgroundColor for consistency

## Files Modified
- `lib/widgets/map/map_view.dart`

## Impact
Eliminates jarring grey background when tiles are loading in dark mode, improving UX consistency across theme changes.

## Before/After
**Before**: Light grey background visible while tiles load (particularly noticeable in dark mode)
**After**: Theme-aware background that matches the app's color scheme

## Test Plan
- [x] Analyzed code - no new issues
- [x] Built Linux release successfully
- [x] Tested in simulator with dark theme
- [x] Verified background matches theme