### PR TITLE
feat(settings): add clock visibility setting

### DIFF
--- a/lib/state/settings.dart
+++ b/lib/state/settings.dart
@@ -27,6 +27,10 @@ class SettingsData with $SettingsData implements Syncable<SettingsData> {
   String? showInternet;
 
   @override
+  @StateField(name: 'dashboard.show-clock', defaultValue: 'always')
+  String? showClock;
+
+  @override
   @StateField(name: 'dashboard.map.type', defaultValue: 'offline')
   MapType mapType;
 
@@ -41,6 +45,7 @@ class SettingsData with $SettingsData implements Syncable<SettingsData> {
     this.showBluetooth,
     this.showCloud,
     this.showInternet,
+    this.showClock,
     this.mapType = MapType.offline,
     this.mapRenderMode = MapRenderMode.raster,
   });

--- a/lib/state/settings.g.dart
+++ b/lib/state/settings.g.dart
@@ -22,6 +22,7 @@ abstract mixin class $SettingsData implements Syncable<SettingsData> {
   String? get showBluetooth;
   String? get showCloud;
   String? get showInternet;
+  String? get showClock;
   MapType get mapType;
   MapRenderMode get mapRenderMode;
   get syncSettings => SyncSettings(
@@ -64,6 +65,13 @@ abstract mixin class $SettingsData implements Syncable<SettingsData> {
             defaultValue: "always",
             interval: null),
         SyncFieldSettings(
+            name: "showClock",
+            variable: "dashboard.show-clock",
+            type: SyncFieldType.string,
+            typeName: "String?",
+            defaultValue: "always",
+            interval: null),
+        SyncFieldSettings(
             name: "mapType",
             variable: "dashboard.map.type",
             type: SyncFieldType.enum_,
@@ -89,6 +97,7 @@ abstract mixin class $SettingsData implements Syncable<SettingsData> {
       showBluetooth: "dashboard.show-bluetooth" != name ? showBluetooth : value,
       showCloud: "dashboard.show-cloud" != name ? showCloud : value,
       showInternet: "dashboard.show-internet" != name ? showInternet : value,
+      showClock: "dashboard.show-clock" != name ? showClock : value,
       mapType: "dashboard.map.type" != name
           ? mapType
           : $_MapTypeMap[value] ?? MapType.offline,
@@ -106,6 +115,7 @@ abstract mixin class $SettingsData implements Syncable<SettingsData> {
       showBluetooth: showBluetooth,
       showCloud: showCloud,
       showInternet: showInternet,
+      showClock: showClock,
       mapType: mapType,
       mapRenderMode: mapRenderMode,
     );
@@ -117,6 +127,7 @@ abstract mixin class $SettingsData implements Syncable<SettingsData> {
         showBluetooth,
         showCloud,
         showInternet,
+        showClock,
         mapType,
         mapRenderMode
       ];
@@ -130,6 +141,7 @@ abstract mixin class $SettingsData implements Syncable<SettingsData> {
     buf.writeln("	showBluetooth = $showBluetooth");
     buf.writeln("	showCloud = $showCloud");
     buf.writeln("	showInternet = $showInternet");
+    buf.writeln("	showClock = $showClock");
     buf.writeln("	mapType = $mapType");
     buf.writeln("	mapRenderMode = $mapRenderMode");
     buf.writeln(")");

--- a/lib/widgets/status_bars/top_status_bar.dart
+++ b/lib/widgets/status_bars/top_status_bar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../cubits/mdb_cubits.dart';
 import '../../cubits/system_cubit.dart';
 import '../../cubits/theme_cubit.dart';
 import '../indicators/status_indicators.dart';
@@ -14,8 +15,10 @@ class StatusBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeState(:theme, :isDark) = ThemeCubit.watch(context);
     final system = SystemCubit.watch(context);
+    final settings = SettingsSync.watch(context);
 
     final textColor = isDark ? Colors.white : Colors.black;
+    final showClock = settings.showClock != 'never';
 
     return Container(
       height: 40,
@@ -38,19 +41,20 @@ class StatusBar extends StatelessWidget {
           ),
 
           // Center - Time
-          Expanded(
-            flex: 1,
-            child: Center(
-              child: Text(
-                system.formattedTime,
-                style: TextStyle(
-                  fontSize: 24,
-                  fontWeight: FontWeight.w500,
-                  color: textColor,
+          if (showClock)
+            Expanded(
+              flex: 1,
+              child: Center(
+                child: Text(
+                  system.formattedTime,
+                  style: TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.w500,
+                    color: textColor,
+                  ),
                 ),
               ),
             ),
-          ),
 
           // Right side - Status Icons
           Expanded(


### PR DESCRIPTION
## Summary
- Add `dashboard.show-clock` Redis setting with values `always` (default) or `never`
- Conditionally render clock in top status bar based on setting
- Resolves #51 by allowing users to hide the clock when system time is incorrect

## Changes
- Added `showClock` field to `SettingsData` class
- Updated top status bar to check setting before displaying clock
- Generated settings sync code

## Test plan
- [x] Verify clock displays by default (setting: `always`)
- [x] Test hiding clock with: `redis-cli SET dashboard.show-clock never`
- [x] Test showing clock with: `redis-cli SET dashboard.show-clock always`
- [x] Verify setting persists across app restarts