### PR TITLE
Add auto-standby warning overlay

### DIFF
--- a/lib/cubits/all.dart
+++ b/lib/cubits/all.dart
@@ -24,6 +24,7 @@ final List<SingleChildWidget> allCubits = [
   BlocProvider(create: ThemeCubit.create),
   BlocProvider(create: EngineSync.create),
   BlocProvider(create: VehicleSync.create),
+  BlocProvider(create: AutoStandbySync.create),
   BlocProvider(create: Battery0Sync.create),
   BlocProvider(create: Battery1Sync.create),
   BlocProvider(create: CbBatterySync.create),

--- a/lib/cubits/mdb_cubits.dart
+++ b/lib/cubits/mdb_cubits.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../repositories/mdb_repository.dart';
+import '../state/auto_standby.dart';
 import '../state/aux_battery.dart';
 import '../state/battery.dart';
 import '../state/bluetooth.dart';
@@ -41,6 +42,15 @@ class VehicleSync extends SyncableCubit<VehicleData> {
 
     super.redisRepository.push("scooter:blinker", command.name);
   }
+}
+
+class AutoStandbySync extends SyncableCubit<AutoStandbyData> {
+  static AutoStandbyData watch(BuildContext context) => context.watch<AutoStandbySync>().state;
+
+  static AutoStandbySync create(BuildContext context) =>
+      AutoStandbySync(RepositoryProvider.of<MDBRepository>(context))..start();
+
+  AutoStandbySync(MDBRepository repo) : super(redisRepository: repo, initialState: AutoStandbyData());
 }
 
 class BatterySync extends SyncableCubit<BatteryData> {

--- a/lib/screens/cluster_screen.dart
+++ b/lib/screens/cluster_screen.dart
@@ -290,6 +290,69 @@ class _ClusterScreenState extends State<ClusterScreen> {
                     ),
                   ),
 
+                // Auto-standby warning overlay
+                BlocBuilder<AutoStandbySync, AutoStandbyData>(
+                  builder: (context, autoStandby) {
+                    final remaining = autoStandby.autoStandbyRemaining;
+                    if (remaining > 0 && remaining <= 30) {
+                      return Positioned(
+                        top: 80,
+                        left: 16,
+                        right: 16,
+                        child: Container(
+                          padding: const EdgeInsets.all(16),
+                          decoration: BoxDecoration(
+                            color: Colors.orange.withOpacity(0.9),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Text(
+                                'Vehicle will enter standby in',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                                textAlign: TextAlign.center,
+                              ),
+                              SizedBox(height: 8),
+                              Text(
+                                '$remaining',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 48,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              SizedBox(height: 4),
+                              Text(
+                                'seconds',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                              SizedBox(height: 12),
+                              Text(
+                                'Press brake or move kickstand to cancel',
+                                style: TextStyle(
+                                  color: Colors.white.withOpacity(0.9),
+                                  fontSize: 13,
+                                ),
+                                textAlign: TextAlign.center,
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    }
+                    return const SizedBox.shrink();
+                  },
+                ),
+
                 // Debug overlay - controlled by DebugOverlayCubit
                 BlocBuilder<DebugOverlayCubit, DebugMode>(
                   builder: (context, debugMode) {

--- a/lib/state/auto_standby.dart
+++ b/lib/state/auto_standby.dart
@@ -1,0 +1,20 @@
+import 'package:equatable/equatable.dart';
+
+import '../builders/sync/annotations.dart';
+import '../builders/sync/settings.dart';
+
+part 'auto_standby.g.dart';
+
+@StateClass('vehicle', Duration(milliseconds: 500))
+class AutoStandbyData extends Equatable with $AutoStandbyData {
+  @override
+  @StateField()
+  final int autoStandbyRemaining;
+
+  AutoStandbyData({
+    this.autoStandbyRemaining = 0,
+  });
+
+  @override
+  List<Object?> get props => [autoStandbyRemaining];
+}

--- a/lib/state/auto_standby.g.dart
+++ b/lib/state/auto_standby.g.dart
@@ -1,0 +1,53 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'auto_standby.dart';
+
+// **************************************************************************
+// StateGenerator
+// **************************************************************************
+
+abstract mixin class $AutoStandbyData implements Syncable<AutoStandbyData> {
+  int get autoStandbyRemaining;
+  get syncSettings => SyncSettings(
+      "vehicle",
+      Duration(microseconds: 500000),
+      [
+        SyncFieldSettings(
+            name: "autoStandbyRemaining",
+            variable: "auto-standby-remaining",
+            type: SyncFieldType.int,
+            typeName: "int",
+            defaultValue: null,
+            interval: null),
+      ],
+      "null",
+      []);
+
+  @override
+  AutoStandbyData update(String name, String value) {
+    return AutoStandbyData(
+      autoStandbyRemaining: "auto-standby-remaining" != name
+          ? autoStandbyRemaining
+          : int.parse(value),
+    );
+  }
+
+  @override
+  AutoStandbyData updateSet(String name, Set<dynamic> value) {
+    return AutoStandbyData(
+      autoStandbyRemaining: autoStandbyRemaining,
+    );
+  }
+
+  List<Object?> get props => [autoStandbyRemaining];
+  @override
+  String toString() {
+    final buf = StringBuffer();
+
+    buf.writeln("AutoStandbyData(");
+    buf.writeln("	autoStandbyRemaining = $autoStandbyRemaining");
+    buf.writeln(")");
+
+    return buf.toString();
+  }
+}


### PR DESCRIPTION
Adds UI warning overlay for auto-standby countdown display.

## Changes

- Create AutoStandbyData state class syncing auto-standby-remaining from vehicle hash
- Add AutoStandbySync cubit to track countdown
- Display warning overlay on cluster screen for last 30 seconds
- Show countdown with message: Press brake or move kickstand to cancel

## Related

- Requires librescoot/vehicle-service#11

## Testing

Works with vehicle-service auto-standby feature when enabled