### PR TITLE
feat: publish navigation availability to Redis

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -42,6 +42,12 @@ class AppConfig {
   /// Redis language setting key
   static const String languageSettingKey = 'dashboard.language';
 
+  /// Redis key for map tiles availability
+  static const String mapsAvailableKey = 'dashboard.maps-available';
+
+  /// Redis key for full navigation availability (maps + routing engine)
+  static const String navigationAvailableKey = 'dashboard.navigation-available';
+
   /// Auto theme light threshold (lux) - switch to light theme above this value
   static const double autoThemeLightThreshold = 25.0;
 

--- a/lib/cubits/all.dart
+++ b/lib/cubits/all.dart
@@ -9,6 +9,7 @@ import 'low_temperature_warning_cubit.dart';
 import 'map_cubit.dart';
 import 'mdb_cubits.dart';
 import 'menu_cubit.dart';
+import 'navigation_availability_cubit.dart';
 import 'navigation_cubit.dart';
 import 'ota_cubit.dart';
 import 'saved_locations_cubit.dart';
@@ -35,6 +36,7 @@ final List<SingleChildWidget> allCubits = [
   BlocProvider(create: GpsSync.create),
   BlocProvider(create: InternetSync.create),
   BlocProvider(create: NavigationSync.create),
+  BlocProvider(create: NavigationAvailabilityCubit.create),
   BlocProvider(
       create: (context) => NavigationCubit(
             gpsStream: context.read<GpsSync>().stream,

--- a/lib/cubits/navigation_availability_cubit.dart
+++ b/lib/cubits/navigation_availability_cubit.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:http/http.dart' as http;
+
+import '../config.dart';
+import '../repositories/mdb_repository.dart';
+import '../repositories/tiles_repository.dart';
+
+class NavigationAvailabilityState {
+  /// Whether local offline display map tiles are present (map.mbtiles).
+  /// Independent of routing availability — online tiles work without this.
+  final bool localDisplayMapsAvailable;
+
+  /// Whether the Valhalla routing engine responds (local or remote endpoint).
+  /// This is what's needed for turn-by-turn navigation.
+  final bool routingAvailable;
+
+  const NavigationAvailabilityState({
+    this.localDisplayMapsAvailable = false,
+    this.routingAvailable = false,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      other is NavigationAvailabilityState &&
+      other.localDisplayMapsAvailable == localDisplayMapsAvailable &&
+      other.routingAvailable == routingAvailable;
+
+  @override
+  int get hashCode => Object.hash(localDisplayMapsAvailable, routingAvailable);
+}
+
+class NavigationAvailabilityCubit extends Cubit<NavigationAvailabilityState> {
+  final TilesRepository _tilesRepository;
+  final MDBRepository _mdbRepository;
+
+  NavigationAvailabilityCubit({
+    required TilesRepository tilesRepository,
+    required MDBRepository mdbRepository,
+  })  : _tilesRepository = tilesRepository,
+        _mdbRepository = mdbRepository,
+        super(const NavigationAvailabilityState()) {
+    _checkAndPublish();
+  }
+
+  static NavigationAvailabilityCubit create(BuildContext context) =>
+      NavigationAvailabilityCubit(
+        tilesRepository: context.read<TilesRepository>(),
+        mdbRepository: RepositoryProvider.of<MDBRepository>(context),
+      );
+
+  static NavigationAvailabilityState watch(BuildContext context) =>
+      context.watch<NavigationAvailabilityCubit>().state;
+
+  Future<void> _checkAndPublish() async {
+    final localDisplayMapsAvailable = await _checkLocalDisplayMapsAvailable();
+    final routingAvailable = await _checkValhallaAvailable();
+
+    try {
+      await _mdbRepository.set(
+          AppConfig.redisSettingsCluster, 'maps-available', localDisplayMapsAvailable ? 'true' : 'false');
+      await _mdbRepository.set(
+          AppConfig.redisSettingsCluster, 'navigation-available', routingAvailable ? 'true' : 'false');
+    } catch (_) {
+      // Redis not yet available
+    }
+
+    emit(NavigationAvailabilityState(
+      localDisplayMapsAvailable: localDisplayMapsAvailable,
+      routingAvailable: routingAvailable,
+    ));
+  }
+
+  Future<bool> _checkLocalDisplayMapsAvailable() async {
+    try {
+      final tiles = await _tilesRepository.getMbTiles();
+      return tiles is Success;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<bool> _checkValhallaAvailable() async {
+    try {
+      final uri = Uri.parse('${AppConfig.valhallaEndpoint}status');
+      final response = await http.get(uri).timeout(const Duration(seconds: 3));
+      return response.statusCode == 200;
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/lib/cubits/screen_cubit.dart
+++ b/lib/cubits/screen_cubit.dart
@@ -17,13 +17,13 @@ class ScreenCubit extends Cubit<ScreenState> {
   late StreamSubscription _settingsSubscription;
   late StreamSubscription _vehicleSubscription;
   ScreenState? _screenBeforeAbout;
-
+  ScreenState? _screenBeforeNavigationSetup;
 
   ScreenCubit(this._settingsService, this._vehicleSync)
       : super(_getInitialState(_settingsService.getScreenSetting())) {
     // Subscribe to settings updates
     _settingsSubscription = _settingsService.settingsStream.listen((settings) {
-      if (state is ScreenAbout) return;
+      if (state is ScreenAbout || state is ScreenNavigationSetup) return;
       final screenMode = _settingsService.getScreenSetting();
       emit(_getInitialState(screenMode));
     });
@@ -88,6 +88,16 @@ class ScreenCubit extends Cubit<ScreenState> {
   void closeAbout() {
     emit(_screenBeforeAbout ?? const ScreenState.cluster());
     _screenBeforeAbout = null;
+  }
+
+  void showNavigationSetup() {
+    _screenBeforeNavigationSetup = state;
+    emit(const ScreenState.navigationSetup());
+  }
+
+  void closeNavigationSetup() {
+    emit(_screenBeforeNavigationSetup ?? const ScreenState.cluster());
+    _screenBeforeNavigationSetup = null;
   }
 
   void _persistScreenMode(String mode) {

--- a/lib/cubits/screen_cubit.freezed.dart
+++ b/lib/cubits/screen_cubit.freezed.dart
@@ -215,4 +215,24 @@ class ScreenAbout implements ScreenState {
   }
 }
 
+/// @nodoc
+
+class ScreenNavigationSetup implements ScreenState {
+  const ScreenNavigationSetup();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is ScreenNavigationSetup);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() {
+    return 'ScreenState.navigationSetup()';
+  }
+}
+
 // dart format on

--- a/lib/cubits/screen_state.dart
+++ b/lib/cubits/screen_state.dart
@@ -11,4 +11,5 @@ sealed class ScreenState with _$ScreenState {
   const factory ScreenState.carplay() = ScreenCarPlay;
   const factory ScreenState.shuttingDown() = ScreenShuttingDown;
   const factory ScreenState.about() = ScreenAbout;
+  const factory ScreenState.navigationSetup() = ScreenNavigationSetup;
 }

--- a/lib/data/menu_structure.dart
+++ b/lib/data/menu_structure.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../cubits/locale_cubit.dart';
 import '../cubits/mdb_cubits.dart';
+import '../cubits/navigation_availability_cubit.dart';
 import '../cubits/menu_cubit.dart';
 import '../cubits/saved_locations_cubit.dart';
 import '../cubits/screen_cubit.dart';
@@ -84,11 +85,25 @@ MenuNode buildMenuTree(BuildContext context) {
         },
       ),
 
-      // Navigation submenu
+      // Navigation unavailable info (shown when routing engine is not available)
+      MenuNode.action(
+        id: 'navigation_setup',
+        title: l10n.menuNavigationSetup,
+        isVisible: (context) =>
+            !context.read<NavigationAvailabilityCubit>().state.routingAvailable,
+        onAction: (context) {
+          context.read<MenuCubit>().hideMenu();
+          context.read<ScreenCubit>().showNavigationSetup();
+        },
+      ),
+
+      // Navigation submenu (only shown when routing engine is available)
       MenuNode.submenu(
         id: 'navigation',
         title: l10n.menuNavigation,
         headerTitle: l10n.menuNavigationHeader,
+        isVisible: (context) =>
+            context.read<NavigationAvailabilityCubit>().state.routingAvailable,
         children: [
           MenuNode.action(
             id: 'nav_enter_code',

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -7,6 +7,13 @@
   "menuSwitchToMap": "Zur Kartenansicht",
   "menuNavigation": "Navigation",
   "menuNavigationHeader": "NAVIGATION",
+  "menuNavigationSetup": "Navigation einrichten",
+
+  "navSetupTitle": "Routing nicht verfügbar",
+  "navSetupLocalDisplayMaps": "Offline-Kartenkacheln",
+  "navSetupRoutingEngine": "Routing-Engine",
+  "navSetupNoRoutingBody": "Kartenanzeige und Routing sind unabhängig. Kartenkacheln können lokal (offline .mbtiles) oder online sein. Für Routing wird eine Valhalla-Engine benötigt — lokal (Routing-Karten erforderlich) oder ein Remote-Server.",
+  "navSetupScanForInstructions": "Für Anleitung scannen",
   "menuEnterDestinationCode": "Zielcode eingeben",
   "menuSavedLocations": "Gespeicherte Orte",
   "menuSavedLocationsHeader": "GESPEICHERTE ORTE",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7,6 +7,13 @@
   "menuSwitchToMap": "Switch to Map View",
   "menuNavigation": "Navigation",
   "menuNavigationHeader": "NAVIGATION",
+  "menuNavigationSetup": "Navigation Setup",
+
+  "navSetupTitle": "Routing Not Available",
+  "navSetupLocalDisplayMaps": "Offline display maps",
+  "navSetupRoutingEngine": "Routing engine",
+  "navSetupNoRoutingBody": "Map display and routing are independent. Display tiles can be local (offline .mbtiles) or online. Routing requires a Valhalla engine — local (needs routing maps) or a remote server.",
+  "navSetupScanForInstructions": "Scan for setup instructions",
   "menuEnterDestinationCode": "Enter Destination Code",
   "menuSavedLocations": "Saved Locations",
   "menuSavedLocationsHeader": "SAVED LOCATIONS",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -128,6 +128,42 @@ abstract class AppLocalizations {
   /// **'NAVIGATION'**
   String get menuNavigationHeader;
 
+  /// No description provided for @menuNavigationSetup.
+  ///
+  /// In en, this message translates to:
+  /// **'Navigation Setup'**
+  String get menuNavigationSetup;
+
+  /// No description provided for @navSetupTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Routing Not Available'**
+  String get navSetupTitle;
+
+  /// No description provided for @navSetupLocalDisplayMaps.
+  ///
+  /// In en, this message translates to:
+  /// **'Offline display maps'**
+  String get navSetupLocalDisplayMaps;
+
+  /// No description provided for @navSetupRoutingEngine.
+  ///
+  /// In en, this message translates to:
+  /// **'Routing engine'**
+  String get navSetupRoutingEngine;
+
+  /// No description provided for @navSetupNoRoutingBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Map display and routing are independent. Display tiles can be local (offline .mbtiles) or online. Routing requires a Valhalla engine — local (needs routing maps) or a remote server.'**
+  String get navSetupNoRoutingBody;
+
+  /// No description provided for @navSetupScanForInstructions.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan for setup instructions'**
+  String get navSetupScanForInstructions;
+
   /// No description provided for @menuEnterDestinationCode.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -27,6 +27,25 @@ class AppLocalizationsDe extends AppLocalizations {
   String get menuNavigationHeader => 'NAVIGATION';
 
   @override
+  String get menuNavigationSetup => 'Navigation einrichten';
+
+  @override
+  String get navSetupTitle => 'Routing nicht verfügbar';
+
+  @override
+  String get navSetupLocalDisplayMaps => 'Offline-Kartenkacheln';
+
+  @override
+  String get navSetupRoutingEngine => 'Routing-Engine';
+
+  @override
+  String get navSetupNoRoutingBody =>
+      'Kartenanzeige und Routing sind unabhängig. Kartenkacheln können lokal (offline .mbtiles) oder online sein. Für Routing wird eine Valhalla-Engine benötigt — lokal (Routing-Karten erforderlich) oder ein Remote-Server.';
+
+  @override
+  String get navSetupScanForInstructions => 'Für Anleitung scannen';
+
+  @override
   String get menuEnterDestinationCode => 'Zielcode eingeben';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -27,6 +27,25 @@ class AppLocalizationsEn extends AppLocalizations {
   String get menuNavigationHeader => 'NAVIGATION';
 
   @override
+  String get menuNavigationSetup => 'Navigation Setup';
+
+  @override
+  String get navSetupTitle => 'Routing Not Available';
+
+  @override
+  String get navSetupLocalDisplayMaps => 'Offline display maps';
+
+  @override
+  String get navSetupRoutingEngine => 'Routing engine';
+
+  @override
+  String get navSetupNoRoutingBody =>
+      'Map display and routing are independent. Display tiles can be local (offline .mbtiles) or online. Routing requires a Valhalla engine — local (needs routing maps) or a remote server.';
+
+  @override
+  String get navSetupScanForInstructions => 'Scan for setup instructions';
+
+  @override
   String get menuEnterDestinationCode => 'Enter Destination Code';
 
   @override

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -20,6 +20,7 @@ import '../widgets/shutdown/shutdown_overlay.dart';
 import '../widgets/ums/ums_overlay.dart';
 import '../widgets/version_overlay.dart';
 import 'about_screen.dart';
+import 'navigation_setup_screen.dart';
 import 'address_selection_screen.dart';
 import 'carplay_screen.dart';
 import 'cluster_screen.dart';
@@ -169,6 +170,7 @@ class _MainScreenState extends State<MainScreen> {
               ScreenOta() => const OtaScreen(),
               ScreenDebug() => const DebugScreen(),
               ScreenAbout() => const AboutScreen(),
+              ScreenNavigationSetup() => const NavigationSetupScreen(),
               ScreenShuttingDown() => menuTrigger(const ClusterScreen()), // Fallback (shouldn't happen)
             },
 

--- a/lib/screens/navigation_setup_screen.dart
+++ b/lib/screens/navigation_setup_screen.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+import '../cubits/mdb_cubits.dart';
+import '../cubits/navigation_availability_cubit.dart';
+import '../cubits/screen_cubit.dart';
+import '../cubits/theme_cubit.dart';
+import '../l10n/l10n.dart';
+import '../widgets/general/control_gestures_detector.dart';
+
+const _docsUrl = 'https://librescoot.org/docs/navigation.html';
+
+class NavigationSetupScreen extends StatelessWidget {
+  const NavigationSetupScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = ThemeCubit.watch(context).isDark;
+    final navState = NavigationAvailabilityCubit.watch(context);
+    final l10n = context.l10n;
+    final vehicleSync = context.read<VehicleSync>();
+
+    final bg = isDark ? Colors.black : Colors.white;
+    final fg = isDark ? Colors.white : Colors.black;
+    final fgDim = isDark ? Colors.white60 : Colors.black54;
+    final divider = isDark ? Colors.white12 : Colors.black12;
+
+    return ControlGestureDetector(
+      stream: vehicleSync.stream,
+      initialData: vehicleSync.state,
+      requireInitialRelease: true,
+      onRightTap: () => context.read<ScreenCubit>().closeNavigationSetup(),
+      child: Container(
+        color: bg,
+        child: Column(
+          children: [
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(32, 48, 32, 24),
+                child: Column(
+                  children: [
+                    Text(
+                      l10n.navSetupTitle,
+                      style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold, color: fg),
+                    ),
+                    const SizedBox(height: 16),
+                    _StatusRow(
+                      label: l10n.navSetupLocalDisplayMaps,
+                      available: navState.localDisplayMapsAvailable,
+                      isDark: isDark,
+                    ),
+                    const SizedBox(height: 8),
+                    _StatusRow(
+                      label: l10n.navSetupRoutingEngine,
+                      available: navState.routingAvailable,
+                      isDark: isDark,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      l10n.navSetupNoRoutingBody,
+                      style: TextStyle(fontSize: 14, color: fgDim, height: 1.4),
+                      textAlign: TextAlign.center,
+                    ),
+                    const Spacer(),
+                    QrImageView(
+                      data: _docsUrl,
+                      version: QrVersions.auto,
+                      size: 140,
+                      backgroundColor: Colors.white,
+                      eyeStyle: const QrEyeStyle(
+                        eyeShape: QrEyeShape.square,
+                        color: Colors.black,
+                      ),
+                      dataModuleStyle: const QrDataModuleStyle(
+                        dataModuleShape: QrDataModuleShape.square,
+                        color: Colors.black,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      l10n.navSetupScanForInstructions,
+                      style: TextStyle(fontSize: 12, color: fgDim),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            // Controls bar
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+              decoration: BoxDecoration(
+                border: Border(top: BorderSide(color: divider)),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  _buildControlHint(l10n.controlRightBrake, l10n.aboutBackAction, fg, fgDim),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildControlHint(String control, String action, Color fg, Color subtle) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          control,
+          style: TextStyle(fontSize: 10, fontWeight: FontWeight.w500, color: subtle, letterSpacing: 0.5),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          action,
+          style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold, color: fg),
+        ),
+      ],
+    );
+  }
+}
+
+class _StatusRow extends StatelessWidget {
+  final String label;
+  final bool available;
+  final bool isDark;
+
+  const _StatusRow({
+    required this.label,
+    required this.available,
+    required this.isDark,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final fg = isDark ? Colors.white : Colors.black;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(
+          available ? Icons.check_circle_outline : Icons.cancel_outlined,
+          color: available ? Colors.green : Colors.red.shade400,
+          size: 18,
+        ),
+        const SizedBox(width: 8),
+        Text(label, style: TextStyle(fontSize: 15, color: fg)),
+      ],
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -737,6 +737,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  qr_flutter:
+    dependency: "direct main"
+    description:
+      name: qr_flutter
+      sha256: "5095f0fc6e3f71d08adef8feccc8cea4f12eec18a2e31c2e8d82cb6019f4b097"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   rbush:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   oktoast: ^3.4.0
   http: ^1.3.0
   window_manager: ^0.4.3
+  qr_flutter: ^4.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Implements [#87](https://github.com/librescoot/scootui/issues/87) — writes navigation availability to Redis and gives users guidance when routing is not yet set up.

### Key design points

Map display and routing are **independent** features:

| Feature | Offline | Online |
|---------|---------|--------|
| Map display | Local `.mbtiles` file | Internet tile server |
| Routing | Local Valhalla + routing maps | Remote Valhalla server |

The old code incorrectly required local display tiles for `navigationAvailable`. Fixed: `routingAvailable` = Valhalla endpoint responds (regardless of tile source).

### Changes

- `NavigationAvailabilityState` now has `localDisplayMapsAvailable` and `routingAvailable` as clearly named independent fields
- Removed 30s retry timer — check once per session
- When routing is unavailable, shows **"Navigation Setup"** in the menu instead of hiding navigation entirely
- Tapping it opens `NavigationSetupScreen`: shows status of both offline display maps and routing engine with green/red indicators, explanatory text, and a QR code
- QR code links to [librescoot.org/docs/navigation.html](https://librescoot.org/docs/navigation.html) — new docs page explaining both axes clearly
- Adds `qr_flutter` dependency

## Test plan

- [ ] No Valhalla running: "Navigation Setup" appears in menu; tapping shows setup screen with routing engine red
- [ ] Valhalla running, no local tiles: "Navigation" submenu appears; setup screen shows local maps red, routing green
- [ ] Both available: "Navigation" submenu appears normally
- [ ] QR code scans correctly to librescoot.org/docs/navigation.html
- [ ] Redis: `dashboard:maps-available` and `dashboard:navigation-available` written on startup