### PR TITLE
feat: resilient Redis connection and startup UX

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -269,5 +269,9 @@
   "carplayInitializingStream": "MJPEG-Stream wird initialisiert",
   "carplayConnectionError": "CarPlay-Verbindungsfehler",
   "carplayRetryConnection": "Erneut verbinden",
-  "carplayWaitingForVideo": "Warte auf Video..."
+  "carplayWaitingForVideo": "Warte auf Video...",
+
+  "connectingTitle": "Verbindung zum Fahrzeugsystem wird hergestellt...",
+  "connectingExplanation": "Dies deutet in der Regel auf eine fehlende oder instabile Verbindung zwischen dem Dashboard-Computer (DBC) und dem Middle Driver Board (MDB) hin. Überprüfe das USB-Kabel, falls das Problem anhält.",
+  "connectingBypassHint": "Um den Fahrmodus trotzdem zu aktivieren, klappe den Seitenständer hoch, halte beide Bremsen und drücke den Sitzbankknopf."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -415,5 +415,9 @@
   "carplayInitializingStream": "Initializing MJPEG stream",
   "carplayConnectionError": "CarPlay Connection Error",
   "carplayRetryConnection": "Retry Connection",
-  "carplayWaitingForVideo": "Waiting for video..."
+  "carplayWaitingForVideo": "Waiting for video...",
+
+  "connectingTitle": "Trying to connect to vehicle system...",
+  "connectingExplanation": "This usually indicates a missing or unreliable connection between the dashboard computer (DBC) and the middle driver board (MDB). Check the USB cable if this persists.",
+  "connectingBypassHint": "To put your scooter into drive mode anyway, raise the kickstand, hold both brakes and press the seatbox button."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1573,6 +1573,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Waiting for video...'**
   String get carplayWaitingForVideo;
+
+  /// No description provided for @connectingTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Trying to connect to vehicle system...'**
+  String get connectingTitle;
+
+  /// No description provided for @connectingExplanation.
+  ///
+  /// In en, this message translates to:
+  /// **'This usually indicates a missing or unreliable connection between the dashboard computer (DBC) and the middle driver board (MDB). Check the USB cable if this persists.'**
+  String get connectingExplanation;
+
+  /// No description provided for @connectingBypassHint.
+  ///
+  /// In en, this message translates to:
+  /// **'To put your scooter into drive mode anyway, raise the kickstand, hold both brakes and press the seatbox button.'**
+  String get connectingBypassHint;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -805,4 +805,15 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get carplayWaitingForVideo => 'Warte auf Video...';
+
+  @override
+  String get connectingTitle => 'Verbindung zum Fahrzeugsystem wird hergestellt...';
+
+  @override
+  String get connectingExplanation =>
+      'Dies deutet in der Regel auf eine fehlende oder instabile Verbindung zwischen dem Dashboard-Computer (DBC) und dem Middle Driver Board (MDB) hin. Überprüfe das USB-Kabel, falls das Problem anhält.';
+
+  @override
+  String get connectingBypassHint =>
+      'Um den Fahrmodus trotzdem zu aktivieren, klappe den Seitenständer hoch, halte beide Bremsen und drücke den Sitzbankknopf.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -805,4 +805,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get carplayWaitingForVideo => 'Waiting for video...';
+
+  @override
+  String get connectingTitle => 'Trying to connect to vehicle system...';
+
+  @override
+  String get connectingExplanation =>
+      'This usually indicates a missing or unreliable connection between the dashboard computer (DBC) and the middle driver board (MDB). Check the USB cable if this persists.';
+
+  @override
+  String get connectingBypassHint =>
+      'To put your scooter into drive mode anyway, raise the kickstand, hold both brakes and press the seatbox button.';
 }

--- a/lib/repositories/redis_mdb_repository.dart
+++ b/lib/repositories/redis_mdb_repository.dart
@@ -126,7 +126,6 @@ class RedisMDBRepository implements MDBRepository {
 
   Timer? _reconnectTimer;
   int _reconnectAttempts = 0;
-  static const int _maxReconnectAttempts = 10;
 
   static String getRedisHost() {
     // Use an environment variable to determine the Redis host, defaulting to the target system address
@@ -343,11 +342,6 @@ class RedisMDBRepository implements MDBRepository {
   }
 
   Future<void> _attemptReconnect() async {
-    if (_reconnectAttempts >= _maxReconnectAttempts) {
-      print('RedisMDBRepository: Max reconnection attempts reached');
-      return;
-    }
-
     _reconnectAttempts++;
     _updateConnectionState(RedisConnectionState.reconnecting);
 

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -101,10 +101,14 @@ class _MainScreenState extends State<MainScreen> {
     };
 
     if (!allowedStates.contains(vehicleState)) {
+      final stateRaw = context.read<VehicleSync>().state.stateRaw;
       return SizedBox(
         width: EnvConfig.resolution.width,
         height: EnvConfig.resolution.height,
-        child: MaintenanceScreen(stateRaw: context.read<VehicleSync>().state.stateRaw),
+        child: MaintenanceScreen(
+          stateRaw: stateRaw,
+          showConnectionInfo: vehicleState == ScooterState.unknown,
+        ),
       );
     }
 

--- a/lib/screens/maintenance_screen.dart
+++ b/lib/screens/maintenance_screen.dart
@@ -1,25 +1,39 @@
 import 'package:flutter/material.dart';
 
+import '../l10n/l10n.dart';
+
 class MaintenanceScreen extends StatelessWidget {
   final String? stateRaw;
+  final bool showConnectionInfo;
 
-  const MaintenanceScreen({super.key, this.stateRaw});
+  const MaintenanceScreen({
+    super.key,
+    this.stateRaw,
+    this.showConnectionInfo = false,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final l10n = showConnectionInfo
+        ? Localizations.of<AppLocalizations>(context, AppLocalizations)
+        : null;
+
     return Container(
       color: Colors.black,
       child: Stack(
         children: [
-          const Center(
-            child: SizedBox(
-              width: 24,
-              height: 24,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-              ),
-            ),
+          Center(
+            child: showConnectionInfo
+                ? _buildConnectionInfo(l10n)
+                : const SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      valueColor:
+                          AlwaysStoppedAnimation<Color>(Colors.white),
+                    ),
+                  ),
           ),
           if (stateRaw != null && stateRaw!.isNotEmpty)
             Positioned(
@@ -37,6 +51,74 @@ class MaintenanceScreen extends StatelessWidget {
                 ),
               ),
             ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildConnectionInfo(AppLocalizations? l10n) {
+    final title = l10n?.connectingTitle
+        ?? 'Trying to connect to vehicle system...';
+    final explanation = l10n?.connectingExplanation
+        ?? 'This usually indicates a missing or unreliable connection between the dashboard computer (DBC) and the middle driver board (MDB). Check the USB cable if this persists.';
+    final bypass = l10n?.connectingBypassHint
+        ?? 'To put your scooter into drive mode anyway, raise the kickstand, hold both brakes and press the seatbox button.';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const SizedBox(
+            width: 36,
+            height: 36,
+            child: CircularProgressIndicator(
+              strokeWidth: 3,
+              valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 20,
+              fontWeight: FontWeight.w600,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          Container(
+            height: 1,
+            color: Colors.white24,
+          ),
+          const SizedBox(height: 20),
+          Text(
+            explanation,
+            style: const TextStyle(
+              color: Colors.white70,
+              fontSize: 14,
+              fontWeight: FontWeight.w400,
+              height: 1.5,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 20),
+          Container(
+            height: 1,
+            color: Colors.white24,
+          ),
+          const SizedBox(height: 20),
+          Text(
+            bypass,
+            style: const TextStyle(
+              color: Colors.white60,
+              fontSize: 14,
+              fontWeight: FontWeight.w400,
+              height: 1.5,
+            ),
+            textAlign: TextAlign.center,
+          ),
         ],
       ),
     );

--- a/lib/state/vehicle.dart
+++ b/lib/state/vehicle.dart
@@ -13,6 +13,7 @@ enum HandleBarLockSensor { locked, unlocked }
 enum SeatboxLock { open, closed }
 
 enum ScooterState {
+  unknown,
   standBy,
   readyToDrive,
   off,
@@ -70,7 +71,7 @@ class VehicleData with $VehicleData {
   Kickstand kickstand;
 
   @override
-  @StateField(defaultValue: "off")
+  @StateField(defaultValue: "unknown")
   ScooterState state;
 
   @override
@@ -108,7 +109,7 @@ class VehicleData with $VehicleData {
   VehicleData({
     this.blinkerSwitch = BlinkerSwitch.off,
     this.blinkerState = BlinkerState.off,
-    this.state = ScooterState.off,
+    this.state = ScooterState.unknown,
     this.stateRaw = "",
     this.kickstand = Kickstand.down,
     this.handleBarLockSensor = HandleBarLockSensor.locked,

--- a/lib/state/vehicle.g.dart
+++ b/lib/state/vehicle.g.dart
@@ -120,7 +120,7 @@ abstract mixin class $VehicleData implements Syncable<VehicleData> {
             variable: "state",
             type: SyncFieldType.enum_,
             typeName: "ScooterState",
-            defaultValue: "off",
+            defaultValue: "unknown",
             interval: null),
         SyncFieldSettings(
             name: "stateRaw",
@@ -193,7 +193,7 @@ abstract mixin class $VehicleData implements Syncable<VehicleData> {
           : $_KickstandMap[value] ?? Kickstand.down,
       state: "state" != name
           ? state
-          : $_ScooterStateMap[value] ?? ScooterState.off,
+          : $_ScooterStateMap[value] ?? ScooterState.unknown,
       stateRaw: "state" != name ? stateRaw : value,
       handleBarLockSensor: "handlebar:lock-sensor" != name
           ? handleBarLockSensor

--- a/lib/widgets/debug/debug_overlay.dart
+++ b/lib/widgets/debug/debug_overlay.dart
@@ -461,6 +461,7 @@ class _DebugOverlayState extends State<DebugOverlay> {
       ScooterState.readyToDrive => Colors.green,
       ScooterState.standBy => Colors.blue,
       ScooterState.parked => Colors.orange,
+      ScooterState.unknown => Colors.grey,
       ScooterState.off => Colors.grey,
       ScooterState.booting => Colors.purple,
       ScooterState.shuttingDown => Colors.red,


### PR DESCRIPTION
- Remove max reconnect attempt cap, now retries indefinitely with existing backoff (1s, 2s, 5s, 10s, 10s...)
- Add `ScooterState.unknown` as the initial default so "no data yet" is distinguishable from "vehicle is off"
- Show informative connection screen when state is unknown: explains DBC-MDB connectivity and manual bypass (kickstand + brakes + seatbox button)

- [x] Start scootui without Redis → shows connection info screen with spinner, explanation, and bypass hint
- [x] Start Redis → scootui recovers and shows normal UI
- [x] Kill Redis while running → toast "Connection lost", retries indefinitely
- [x] Restart Redis → recovers automatically